### PR TITLE
fix: Rework variants to use nested objects.

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "aesthetic": "aesthetic",
     "prepare": "beemo create-config --silent",
-    "build": "beemo create-config babel --esm --silent && rollup --config && yarn run type",
+    "build": "beemo create-config babel --esm --silent && rollup --config",
     "clean": "rm -rf ./packages/*/{lib,esm,*.tsbuildinfo}",
     "coverage": "yarn run jest --coverage",
     "format": "beemo prettier",

--- a/packages/core/tests/Aesthetic.test.ts
+++ b/packages/core/tests/Aesthetic.test.ts
@@ -372,8 +372,10 @@ describe('Aesthetic', () => {
           color: 'black',
 
           '@variants': {
-            type_red: {
-              color: 'red',
+            type: {
+              red: {
+                color: 'red',
+              },
             },
           },
         },

--- a/packages/sss/src/helpers/formatFontFace.ts
+++ b/packages/sss/src/helpers/formatFontFace.ts
@@ -1,7 +1,7 @@
 import CSS from 'csstype';
 import { FontFace } from '../types';
 
-const FORMATS: { [ext: string]: string } = {
+const FORMATS: Record<string, string> = {
   '.eot': 'embedded-opentype',
   '.otf': 'opentype',
   '.svg': 'svg',

--- a/packages/sss/src/types.ts
+++ b/packages/sss/src/types.ts
@@ -166,9 +166,7 @@ export type FallbackProperties = CSST.StandardPropertiesFallback<Value>;
 
 export type Rule = Declarations<Properties>;
 
-export interface RuleMap<T> {
-  [selector: string]: T;
-}
+export type RuleMap<T> = Record<string, T>;
 
 export interface FontFace extends BaseFontFace {
   local?: string[];
@@ -228,12 +226,16 @@ export type LocalAtRule =
 
 export type LocalBlock = Rule & {
   '@fallbacks'?: FallbackProperties;
-  '@media'?: { [mediaQuery: string]: LocalBlock };
-  '@selectors'?: { [selector: string]: LocalBlock };
-  '@supports'?: { [featureQuery: string]: LocalBlock };
+  '@media'?: LocalBlockMap;
+  '@selectors'?: LocalBlockMap;
+  '@supports'?: LocalBlockMap;
   '@variables'?: Variables;
-  '@variants'?: { [variant: string]: LocalBlock };
+  '@variants'?: LocalBlockVariants;
 };
+
+export type LocalBlockMap = Record<string, LocalBlock>;
+
+export type LocalBlockVariants = Record<string, LocalBlockMap>;
 
 export type LocalBlockNeverize<T> = {
   [K in keyof T]: K extends keyof LocalBlock ? T[K] : never;
@@ -257,9 +259,9 @@ export type GlobalAtRule =
   | '@viewport';
 
 export interface GlobalStyleSheet {
-  '@font-face'?: { [fontFamily: string]: FontFace | FontFace[] };
+  '@font-face'?: Record<string, FontFace | FontFace[]>;
   '@import'?: (string | Import)[];
-  '@keyframes'?: { [animationName: string]: Keyframes };
+  '@keyframes'?: Record<string, Keyframes>;
   '@page'?: Page;
   '@root'?: LocalBlock;
   '@variables'?: Variables;

--- a/packages/sss/tests/__mocks__/local.ts
+++ b/packages/sss/tests/__mocks__/local.ts
@@ -168,14 +168,16 @@ export const SYNTAX_VARIABLES: LocalBlock = {
 
 export const SYNTAX_VARIANTS: LocalBlock = {
   '@variants': {
-    size_small: {
-      fontSize: 14,
-    },
-    size_default: {
-      fontSize: 16,
-    },
-    size_large: {
-      fontSize: 18,
+    size: {
+      small: {
+        fontSize: 14,
+      },
+      default: {
+        fontSize: 16,
+      },
+      large: {
+        fontSize: 18,
+      },
     },
   },
 };


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/aesthetic-suite/framework/blob/main/CONTRIBUTING.md
-->

<!-- If fixing an issue, uncomment the following and include a link/issue number. -->

<!-- Fixes issue # -->

## Summary

Changes the former structure of:

```ts
'@variants': {
  size_sm: css.mixin('text-sm', {
    minWidth: css.unit(4),
    padding: {
      leftRight: css.var('spacing-sm'),
      topBottom: css.var('spacing-xs'),
    },
  }),
  size_df: css.mixin('text-df', {
    minWidth: css.unit(6),
    padding: {
      leftRight: css.var('spacing-df'),
      topBottom: css.var('spacing-sm'),
    },
  }),
  size_lg: css.mixin('text-lg', {
    minWidth: css.unit(8),
    padding: {
      leftRight: css.var('spacing-md'),
      topBottom: css.var('spacing-df'),
    },
  }),
},
```

To:

```ts
'@variants': {
  size: {
    sm: css.mixin('text-sm', {
      minWidth: css.unit(4),
      padding: {
        leftRight: css.var('spacing-sm'),
        topBottom: css.var('spacing-xs'),
      },
    }),
    df: css.mixin('text-df', {
      minWidth: css.unit(6),
      padding: {
        leftRight: css.var('spacing-df'),
        topBottom: css.var('spacing-sm'),
      },
    }),
    lg: css.mixin('text-lg', {
      minWidth: css.unit(8),
      padding: {
        leftRight: css.var('spacing-md'),
        topBottom: css.var('spacing-df'),
      },
    }),
  },
},
```

Since it's easier to read and naturally groups related variants.

## Screenshots

<!-- If applicable, screenshots or videos of the change working correctly. -->

## Checklist

- [x] Build passes with `yarn test`.
- [x] Code is formatted with `yarn format`.
- [x] Tests have been added for my changes.
- [x] Code coverage for my change is 100%.
- [x] Documentation has been updated for my changes.
