### PR TITLE
build: Reduce `system` package size.

### DIFF
--- a/packages/core/src/GlobalSheet.ts
+++ b/packages/core/src/GlobalSheet.ts
@@ -21,7 +21,7 @@ export default class GlobalSheet<T = unknown> extends Sheet<ClassName> {
   protected doRender(renderer: Renderer, theme: Theme, params: Required<SheetParams>): ClassName {
     let className = '';
     const composer = this.compose();
-    const styles = composer(theme.toUtilities(), theme.toTokens());
+    const styles = composer(theme, theme.tokens);
     const renderParams = {
       rtl: params.direction === 'rtl',
       unit: params.unit,

--- a/packages/core/src/LocalSheet.ts
+++ b/packages/core/src/LocalSheet.ts
@@ -80,7 +80,7 @@ export default class LocalSheet<T = unknown> extends Sheet<ClassNameSheet<string
   ): ClassNameSheet<string> {
     const classNames: ClassNameSheet<string> = {};
     const composer = this.compose(params);
-    const styles = composer(theme.toUtilities(), theme.toTokens());
+    const styles = composer(theme, theme.tokens);
     const rankCache = {};
     const renderParams = {
       rankings: rankCache,

--- a/packages/system/src/Design.ts
+++ b/packages/system/src/Design.ts
@@ -17,7 +17,6 @@ export default class Design {
   constructor(name: string, tokens: Omit<DesignTokens, 'depth'>) {
     this.name = name;
     this.tokens = { ...tokens, depth: DEPTHS };
-
     this.rootLineHeight = tokens.typography.rootLineHeight;
     this.rootTextSize = Number.parseFloat(tokens.typography.rootTextSize);
 

--- a/packages/system/src/Design.ts
+++ b/packages/system/src/Design.ts
@@ -12,12 +12,11 @@ export default class Design {
 
   readonly spacingUnit: number;
 
-  protected tokens: DesignTokens;
+  readonly tokens: DesignTokens;
 
   constructor(name: string, tokens: Omit<DesignTokens, 'depth'>) {
     this.name = name;
-    this.tokens = tokens as DesignTokens;
-    this.tokens.depth = DEPTHS;
+    this.tokens = { ...tokens, depth: DEPTHS };
 
     this.rootLineHeight = tokens.typography.rootLineHeight;
     this.rootTextSize = Number.parseFloat(tokens.typography.rootTextSize);
@@ -38,12 +37,5 @@ export default class Design {
    */
   extend(name: string, tokens: DeepPartial<DesignTokens>): Design {
     return new Design(name, deepMerge(this.tokens, tokens));
-  }
-
-  /**
-   * Return current design tokens.
-   */
-  getTokens(): DesignTokens {
-    return this.tokens;
   }
 }

--- a/packages/system/src/Theme.ts
+++ b/packages/system/src/Theme.ts
@@ -33,20 +33,20 @@ import { uiBox, uiInteractive } from './mixins/ui';
 type AnyObject = Record<string, any>;
 type MixinTemplates = Record<string, Set<MixinTemplate>>;
 
-export default class Theme {
+export default class Theme implements Utilities {
   name: string = '';
 
   readonly contrast: ContrastLevel;
 
+  readonly mixin: MixinUtils;
+
   readonly scheme: ColorScheme;
+
+  readonly tokens: Tokens;
 
   protected mixins: Record<string, MixinTemplate> = {};
 
   protected mixinTemplates: MixinTemplates = {};
-
-  protected tokens: ThemeTokens;
-
-  private cachedTokens?: Tokens;
 
   private cachedVariables?: Variables;
 
@@ -61,16 +61,18 @@ export default class Theme {
     this.contrast = options.contrast;
     this.scheme = options.scheme;
     this.design = design;
-    this.tokens = tokens;
+    this.tokens = {
+      ...design.tokens,
+      ...tokens,
+    };
     this.mixinTemplates = parentTemplates;
 
     // Bind instead of using anonymous functions since we need
     // to pass these around and define properties on them!
-    this.mixin = this.mixin.bind(this);
+    this.mixin = this.prepareBuiltIns();
     this.token = this.token.bind(this);
     this.unit = this.unit.bind(this);
     this.var = this.var.bind(this);
-    this.prepareBuiltIns();
   }
 
   /**
@@ -93,11 +95,7 @@ export default class Theme {
    * Extend a registered mixin with additional CSS properties.
    */
   extendMixin(name: MixinType, template: MixinTemplate): this {
-    const set = this.mixinTemplates[name] || new Set();
-
-    set.add(template);
-
-    this.mixinTemplates[name] = set;
+    this.mixinTemplates[name] = (this.mixinTemplates[name] || new Set()).add(template);
 
     return this;
   }
@@ -115,32 +113,6 @@ export default class Theme {
     this.mixins[name] = template;
 
     return this;
-  }
-
-  /**
-   * Return both design and theme tokens.
-   */
-  toTokens(): Tokens {
-    if (!this.cachedTokens) {
-      this.cachedTokens = {
-        ...this.design.getTokens(),
-        ...this.tokens,
-      };
-    }
-
-    return this.cachedTokens;
-  }
-
-  /**
-   * Return a mapping of all theme specific utility methods.
-   */
-  toUtilities(): Utilities {
-    return {
-      mixin: this.mixin as MixinUtils,
-      token: this.token,
-      unit: this.unit,
-      var: this.var,
-    };
   }
 
   /**
@@ -164,7 +136,7 @@ export default class Theme {
       });
     };
 
-    collapseTree(this.toTokens(), []);
+    collapseTree(this.tokens, []);
 
     this.cachedVariables = (vars as unknown) as Variables;
 
@@ -175,12 +147,12 @@ export default class Theme {
    * Return merged CSS properties from the defined mixin, all template overrides,
    * and the provided additional CSS properties.
    */
-  mixin(name: MixinType, options?: object, ...additionalRules: Rule[]): Rule {
+  mixinBase(name: MixinType, options: object = {}, ...additionalRules: Rule[]): Rule {
     const rules: Rule[] = [];
     const mixin = this.mixins[name];
 
     if (mixin) {
-      rules.push(this.callMixinTemplate(mixin, options));
+      rules.push(mixin.call(this, options));
     } else if (__DEV__) {
       // Log instead of error since mixins are dynamic
       // eslint-disable-next-line no-console
@@ -191,17 +163,13 @@ export default class Theme {
 
     if (templates) {
       templates.forEach((template) => {
-        rules.push(this.callMixinTemplate(template, options));
+        rules.push(template.call(this, options));
       });
     }
 
     rules.push(...additionalRules);
 
-    if (rules.length === 0) {
-      return {};
-    }
-
-    return deepMerge(...rules);
+    return rules.length === 0 ? {} : deepMerge(...rules);
   }
 
   /**
@@ -237,23 +205,14 @@ export default class Theme {
    * Return a CSS variable declaration with the defined name and fallbacks.
    */
   var(name: VariableName, ...fallbacks: (string | number)[]): string {
-    return fallbacks.length > 0
-      ? `var(${[`--${name}`, ...fallbacks].join(', ')})`
-      : `var(--${name})`;
-  }
-
-  /**
-   * Call a mixin template function with the defined options object.
-   * Will set the "this" context to the utilities object, so that mixins can utilize them.
-   */
-  protected callMixinTemplate(mixin: MixinTemplate, options: object = {}): Rule {
-    return mixin.call(this.toUtilities(), options);
+    return `var(${[`--${name}`, ...fallbacks].join(', ')})`;
   }
 
   /**
    * Set the built-in mixin's as properties on the mixin method for easy access.
    */
-  protected prepareBuiltIns() {
+  protected prepareBuiltIns(): MixinUtils {
+    const mixin = this.mixinBase.bind(this);
     const builtIns: Record<keyof MixinBuiltInUtils, MixinTemplate> = {
       background,
       border,
@@ -277,16 +236,18 @@ export default class Theme {
       uiInteractive,
     };
 
-    objectLoop(builtIns, (mixin, name) => {
+    objectLoop(builtIns, (template, name) => {
       const type = hyphenate(name) as MixinType;
 
       // Register the mixin
-      this.registerMixin(type, mixin);
+      this.registerMixin(type, template);
 
       // Provide a utility function
-      const util: MixinUtil = (options, properties) => this.mixin(type, options, properties!);
+      const util: MixinUtil = (options, properties) => mixin(type, options, properties!);
 
-      Object.defineProperty(this.mixin, name, { value: util });
+      Object.defineProperty(mixin, name, { value: util });
     });
+
+    return mixin as MixinUtils;
   }
 }

--- a/packages/system/src/Theme.ts
+++ b/packages/system/src/Theme.ts
@@ -46,7 +46,7 @@ export default class Theme implements Utilities {
 
   protected mixins: Record<string, MixinTemplate> = {};
 
-  protected mixinTemplates: MixinTemplates = {};
+  protected templates: MixinTemplates = {};
 
   private cachedVariables?: Variables;
 
@@ -61,11 +61,8 @@ export default class Theme implements Utilities {
     this.contrast = options.contrast;
     this.scheme = options.scheme;
     this.design = design;
-    this.tokens = {
-      ...design.tokens,
-      ...tokens,
-    };
-    this.mixinTemplates = parentTemplates;
+    this.tokens = { ...design.tokens, ...tokens };
+    this.templates = parentTemplates;
 
     // Bind instead of using anonymous functions since we need
     // to pass these around and define properties on them!
@@ -87,7 +84,7 @@ export default class Theme implements Utilities {
       },
       deepMerge(this.tokens, tokens),
       this.design,
-      { ...this.mixinTemplates },
+      { ...this.templates },
     );
   }
 
@@ -95,7 +92,7 @@ export default class Theme implements Utilities {
    * Extend a registered mixin with additional CSS properties.
    */
   extendMixin(name: MixinType, template: MixinTemplate): this {
-    this.mixinTemplates[name] = (this.mixinTemplates[name] || new Set()).add(template);
+    this.templates[name] = (this.templates[name] || new Set()).add(template);
 
     return this;
   }
@@ -159,7 +156,7 @@ export default class Theme implements Utilities {
       console.warn(`Unknown mixin "${name}".`);
     }
 
-    const templates = this.mixinTemplates[name];
+    const templates = this.templates[name];
 
     if (templates) {
       templates.forEach((template) => {

--- a/packages/system/src/ThemeRegistry.ts
+++ b/packages/system/src/ThemeRegistry.ts
@@ -3,26 +3,26 @@ import Theme from './Theme';
 import { ColorScheme, ContrastLevel, ThemeOptions } from './types';
 
 export default class ThemeRegistry {
-  protected defaultDarkTheme: string = '';
-
-  protected defaultLightTheme: string = '';
+  protected darkTheme: string = '';
 
   protected defaultTheme: string = '';
 
-  protected themes: { [name: string]: Theme } = {};
+  protected lightTheme: string = '';
+
+  protected themes: Record<string, Theme> = {};
 
   /**
    * Return the default dark theme.
    */
   getDarkTheme(): Theme {
-    return this.getTheme(this.defaultDarkTheme);
+    return this.getTheme(this.darkTheme);
   }
 
   /**
    * Return the default light theme.
    */
   getLightTheme(): Theme {
-    return this.getTheme(this.defaultLightTheme);
+    return this.getTheme(this.lightTheme);
   }
 
   /**
@@ -83,11 +83,13 @@ export default class ThemeRegistry {
 
     const theme = this.themes[name];
 
-    if (theme) {
-      return theme;
+    if (__DEV__) {
+      if (!theme) {
+        throw new Error(`Theme "${name}" does not exist. Has it been registered?`);
+      }
     }
 
-    throw new Error(`Theme "${name}" does not exist. Has it been registered?`);
+    return theme;
   }
 
   /**
@@ -121,23 +123,19 @@ export default class ThemeRegistry {
       }
 
       if (isDefault) {
-        if (theme.scheme === 'dark' && this.defaultDarkTheme) {
-          throw new Error(
-            `"${this.defaultDarkTheme}" is already registered as the default dark theme.`,
-          );
-        } else if (theme.scheme === 'light' && this.defaultLightTheme) {
-          throw new Error(
-            `"${this.defaultLightTheme}" is already registered as the default light theme.`,
-          );
+        if (theme.scheme === 'dark' && this.darkTheme) {
+          throw new Error(`"${this.darkTheme}" is already registered as the default dark theme.`);
+        } else if (theme.scheme === 'light' && this.lightTheme) {
+          throw new Error(`"${this.lightTheme}" is already registered as the default light theme.`);
         }
       }
     }
 
     if (isDefault) {
       if (theme.scheme === 'dark') {
-        this.defaultDarkTheme = name;
+        this.darkTheme = name;
       } else {
-        this.defaultLightTheme = name;
+        this.lightTheme = name;
       }
     }
 
@@ -163,8 +161,8 @@ export default class ThemeRegistry {
    * Reset the registry to initial state.
    */
   reset() {
-    this.defaultDarkTheme = '';
-    this.defaultLightTheme = '';
+    this.darkTheme = '';
+    this.lightTheme = '';
     this.themes = {};
   }
 }

--- a/packages/system/tests/Design.test.ts
+++ b/packages/system/tests/Design.test.ts
@@ -9,11 +9,7 @@ describe('Design', () => {
   });
 
   it('can return a theme instance', () => {
-    const theme = design.createTheme(
-      { contrast: 'normal', scheme: 'light' },
-      // @ts-expect-error
-      lightTheme.tokens,
-    );
+    const theme = design.createTheme({ contrast: 'normal', scheme: 'light' }, lightTheme.tokens);
 
     expect(theme).toBeInstanceOf(Theme);
   });
@@ -32,7 +28,7 @@ describe('Design', () => {
 
     expect(newDesign).toBeInstanceOf(Design);
     expect(newDesign.name).toBe('new-design');
-    expect(newDesign.getTokens().spacing.unit).toBe(8);
-    expect(newDesign.getTokens().text.df.size).toBe('20px');
+    expect(newDesign.tokens.spacing.unit).toBe(8);
+    expect(newDesign.tokens.text.df.size).toBe('20px');
   });
 });

--- a/packages/system/tests/Theme.test.ts
+++ b/packages/system/tests/Theme.test.ts
@@ -46,12 +46,12 @@ describe('Theme', () => {
   describe('extendMixin()', () => {
     it('creates a template set for the defined name', () => {
       // @ts-expect-error Allow access
-      expect(testTheme.mixinTemplates.test).toBeUndefined();
+      expect(testTheme.templates.test).toBeUndefined();
 
       testTheme.extendMixin('test', () => ({}));
 
       // @ts-expect-error Allow access
-      expect(testTheme.mixinTemplates.test).toBeInstanceOf(Set);
+      expect(testTheme.templates.test).toBeInstanceOf(Set);
     });
 
     it('doesnt set the same template twice', () => {
@@ -62,7 +62,7 @@ describe('Theme', () => {
       testTheme.extendMixin('test', template);
 
       // @ts-expect-error Allow access
-      expect(testTheme.mixinTemplates.test.size).toBe(1);
+      expect(testTheme.templates.test.size).toBe(1);
     });
 
     it('can extend a mixin with additional properties', () => {

--- a/packages/system/tests/Theme.test.ts
+++ b/packages/system/tests/Theme.test.ts
@@ -32,7 +32,7 @@ describe('Theme', () => {
     expect(newTheme).toBeInstanceOf(Theme);
     expect(newTheme.contrast).toBe('high');
     expect(newTheme.scheme).toBe('light');
-    expect(newTheme.toTokens().palette.brand.color['00']).toBe('red');
+    expect(newTheme.tokens.palette.brand.color['00']).toBe('red');
   });
 
   it('inherits the parents customized mixins', () => {
@@ -161,26 +161,6 @@ describe('Theme', () => {
 
       // @ts-expect-error Allow access
       expect(testTheme.mixins.custom).toBe(template);
-    });
-  });
-
-  describe('toUtilities()', () => {
-    it('returns all factory methods', () => {
-      expect(lightTheme.toUtilities()).toEqual({
-        mixin: lightTheme.mixin,
-        token: lightTheme.token,
-        unit: lightTheme.unit,
-        var: lightTheme.var,
-      });
-    });
-  });
-
-  describe('toTokens()', () => {
-    it('returns design and theme tokens', () => {
-      const tokens = lightTheme.toTokens();
-
-      expect(tokens.spacing.lg).toBeDefined();
-      expect(tokens.palette.warning).toBeDefined();
     });
   });
 

--- a/packages/system/tests/mixins.test.ts
+++ b/packages/system/tests/mixins.test.ts
@@ -2,7 +2,7 @@ import { darkTheme } from '../src/testing';
 import { MixinUtils } from '../src';
 
 describe('Mixins', () => {
-  const mixins: MixinUtils = darkTheme.toUtilities().mixin;
+  const mixins: MixinUtils = darkTheme.mixin;
 
   describe('background', () => {
     it('renders background', () => {

--- a/packages/utils/src/generateHash.ts
+++ b/packages/utils/src/generateHash.ts
@@ -1,6 +1,6 @@
 import hash from 'string-hash';
 
-const cache: { [key: string]: string } = {};
+const cache: Record<string, string> = {};
 
 export default function generateHash(value: string): string {
   if (!cache[value]) {

--- a/packages/utils/src/hyphenate.ts
+++ b/packages/utils/src/hyphenate.ts
@@ -1,6 +1,6 @@
 const CAMEL_CASE_PATTERN = /[A-Z]/gu;
 const VENDOR_PREFIX_PATTERN = /^(ms|moz|webkit)/iu;
-const cache: { [key: string]: string } = {};
+const cache: Record<string, string> = {};
 
 function toLower(match: string): string {
   return `-${match.toLocaleLowerCase()}`;


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/aesthetic-suite/framework/blob/main/CONTRIBUTING.md
-->

<!-- If fixing an issue, uncomment the following and include a link/issue number. -->

<!-- Fixes issue # -->

## Summary

20,388 B -> 19,705 B

Not as much as I hoped, but the bulk of the file size comes from mixins, which we can't really change. However, I did clean up the APIS a bit, so they're now easier to use.

## Screenshots

<!-- If applicable, screenshots or videos of the change working correctly. -->

## Checklist

- [x] Build passes with `yarn test`.
- [x] Code is formatted with `yarn format`.
- [x] Tests have been added for my changes.
- [x] Code coverage for my change is 100%.
- [x] Documentation has been updated for my changes.
