### PR TITLE
internal: Swap mixin argument order.

### DIFF
--- a/packages/addon-mixins/README.md
+++ b/packages/addon-mixins/README.md
@@ -27,9 +27,10 @@ const theme = design.createTheme(
   },
 );
 
-const css = theme.mixin('background', { palette: 'success' });
+const css = theme.mixin('background', { palette: 'success' }, { borderWidth: 1 });
+
 // OR with type safety
-const css = theme.mixin.background({ palette: 'success' });
+const css = theme.mixin.background({ palette: 'success' }, { borderWidth: 1 });
 ```
 
 ## Installation

--- a/packages/addon-mixins/package.json
+++ b/packages/addon-mixins/package.json
@@ -20,9 +20,11 @@
     "access": "public"
   },
   "peerDependencies": {
-    "@aesthetic/system": "^0.3.0",
+    "@aesthetic/system": "^0.3.0"
+  },
+  "dependencies": {
     "@aesthetic/types": "^0.2.0",
-    "@aesthetic/utils": "^0.3.0"
+    "@aesthetic/utils": "^0.4.0"
   },
   "funding": {
     "type": "ko-fi",

--- a/packages/addon-mixins/src/heading.ts
+++ b/packages/addon-mixins/src/heading.ts
@@ -8,14 +8,11 @@ export function heading(this: Utilities, { level = 1 }: HeadingOptions = {}): Ru
     checkList('level', level, [1, 2, 3, 4, 5, 6]);
   }
 
-  return this.mixin.resetTypography(
-    {},
-    {
-      color: this.var('palette-neutral-fg-base'),
-      letterSpacing: this.var(`heading-l${level}-letter-spacing` as 'heading-l1-letter-spacing'),
-      lineHeight: this.var(`heading-l${level}-line-height` as 'heading-l1-line-height'),
-      fontFamily: this.var('typography-font-heading'),
-      fontSize: this.var(`heading-l${level}-size` as 'heading-l1-size'),
-    },
-  );
+  return this.mixin.resetTypography({
+    color: this.var('palette-neutral-fg-base'),
+    letterSpacing: this.var(`heading-l${level}-letter-spacing` as 'heading-l1-letter-spacing'),
+    lineHeight: this.var(`heading-l${level}-line-height` as 'heading-l1-line-height'),
+    fontFamily: this.var('typography-font-heading'),
+    fontSize: this.var(`heading-l${level}-size` as 'heading-l1-size'),
+  });
 }

--- a/packages/addon-mixins/src/text.ts
+++ b/packages/addon-mixins/src/text.ts
@@ -8,15 +8,12 @@ export function text(this: Utilities, { size = 'df' }: TextOptions = {}): Rule {
     checkList('size', size, TEXT_SIZES);
   }
 
-  return this.mixin.resetTypography(
-    {},
-    {
-      color: this.var('palette-neutral-fg-base'),
-      fontFamily: this.var('typography-font-text'),
-      fontSize: this.var(`text-${size}-size` as 'text-df-size'),
-      lineHeight: this.var(`text-${size}-line-height` as 'text-df-line-height'),
-    },
-  );
+  return this.mixin.resetTypography({
+    color: this.var('palette-neutral-fg-base'),
+    fontFamily: this.var('typography-font-text'),
+    fontSize: this.var(`text-${size}-size` as 'text-df-size'),
+    lineHeight: this.var(`text-${size}-line-height` as 'text-df-line-height'),
+  });
 }
 
 export function textBreak(): Rule {

--- a/packages/addon-mixins/src/types.ts
+++ b/packages/addon-mixins/src/types.ts
@@ -1,7 +1,7 @@
 import {
   BorderSize,
   ColorShade,
-  MixinUtil,
+  MixinBuiltIn,
   PaletteType,
   ShadowSize,
   TextSize,
@@ -51,27 +51,27 @@ export interface UIInteractiveOptions {
 }
 
 declare module '@aesthetic/system' {
-  export interface MixinUtils {
-    background: MixinUtil<BackgroundOptions>;
-    border: MixinUtil<BorderOptions>;
-    foreground: MixinUtil<ForegroundOptions>;
-    heading: MixinUtil<HeadingOptions>;
-    hideCompletely: MixinUtil;
-    hideOffscreen: MixinUtil;
-    hideVisually: MixinUtil;
-    resetButton: MixinUtil<ResetButtonOptions>;
-    resetInput: MixinUtil;
-    resetList: MixinUtil;
-    resetMedia: MixinUtil;
-    resetTypography: MixinUtil;
-    root: MixinUtil;
-    shadow: MixinUtil<ShadowOptions>;
-    text: MixinUtil<TextOptions>;
-    textBreak: MixinUtil;
-    textTruncate: MixinUtil;
-    textWrap: MixinUtil;
-    uiBox: MixinUtil<UIBoxOptions>;
-    uiInteractive: MixinUtil<UIInteractiveOptions>;
+  export interface MixinUtil {
+    background: MixinBuiltIn<BackgroundOptions>;
+    border: MixinBuiltIn<BorderOptions>;
+    foreground: MixinBuiltIn<ForegroundOptions>;
+    heading: MixinBuiltIn<HeadingOptions>;
+    hideCompletely: MixinBuiltIn;
+    hideOffscreen: MixinBuiltIn;
+    hideVisually: MixinBuiltIn;
+    resetButton: MixinBuiltIn<ResetButtonOptions>;
+    resetInput: MixinBuiltIn;
+    resetList: MixinBuiltIn;
+    resetMedia: MixinBuiltIn;
+    resetTypography: MixinBuiltIn;
+    root: MixinBuiltIn;
+    shadow: MixinBuiltIn<ShadowOptions>;
+    text: MixinBuiltIn<TextOptions>;
+    textBreak: MixinBuiltIn;
+    textTruncate: MixinBuiltIn;
+    textWrap: MixinBuiltIn;
+    uiBox: MixinBuiltIn<UIBoxOptions>;
+    uiInteractive: MixinBuiltIn<UIInteractiveOptions>;
   }
 }
 

--- a/packages/addon-mixins/src/ui.ts
+++ b/packages/addon-mixins/src/ui.ts
@@ -7,21 +7,24 @@ export function uiBox(
   this: Utilities,
   { border = true, palette = 'neutral', shadow = true }: UIBoxOptions,
 ): Rule {
-  const rule: Rule = this.mixin.background({ palette });
+  const rule: Rule = this.mixin.background({ palette }, {});
 
   if (border) {
     Object.assign(
       rule,
-      this.mixin.border({
-        // Inherit same color as box by default
-        palette,
-        ...(isObject(border) ? border : {}),
-      }),
+      this.mixin.border(
+        {
+          // Inherit same color as box by default
+          palette,
+          ...(isObject(border) ? border : {}),
+        },
+        {},
+      ),
     );
   }
 
   if (shadow) {
-    Object.assign(rule, this.mixin.shadow(isObject(shadow) ? shadow : {}));
+    Object.assign(rule, this.mixin.shadow(isObject(shadow) ? shadow : {}, {}));
   }
 
   return rule;

--- a/packages/addon-mixins/tests/mixins.test.ts
+++ b/packages/addon-mixins/tests/mixins.test.ts
@@ -1,9 +1,9 @@
-import { MixinUtils } from '@aesthetic/system';
+import { MixinUtil } from '@aesthetic/system';
 import { darkTheme } from '@aesthetic/system/lib/testing';
 import mixinTemplates from '../src';
 
 describe('Mixins', () => {
-  let mixins: MixinUtils;
+  let mixins: MixinUtil;
 
   beforeEach(() => {
     // Clone the theme so we dont clobber other tests
@@ -18,16 +18,19 @@ describe('Mixins', () => {
   describe('background', () => {
     it('renders background', () => {
       expect(mixins.background()).toMatchSnapshot();
-      expect(mixins.background({ palette: 'brand' })).toMatchSnapshot();
-      expect(mixins.background({ palette: 'danger' })).toMatchSnapshot();
+      expect(mixins.background({ palette: 'brand' }, {})).toMatchSnapshot();
+      expect(mixins.background({ palette: 'danger' }, {})).toMatchSnapshot();
     });
 
     it('errors for invalid `palette`', () => {
       expect(() =>
-        mixins.background({
-          // @ts-expect-error
-          palette: 'unknown',
-        }),
+        mixins.background(
+          {
+            // @ts-expect-error
+            palette: 'unknown',
+          },
+          {},
+        ),
       ).toThrowErrorMatchingSnapshot();
     });
   });
@@ -35,36 +38,45 @@ describe('Mixins', () => {
   describe('border', () => {
     it('renders border', () => {
       expect(mixins.border()).toMatchSnapshot();
-      expect(mixins.border({ size: 'sm', palette: 'info' })).toMatchSnapshot();
-      expect(mixins.border({ size: 'lg', shade: '50', radius: false })).toMatchSnapshot();
+      expect(mixins.border({ size: 'sm', palette: 'info' }, {})).toMatchSnapshot();
+      expect(mixins.border({ size: 'lg', shade: '50', radius: false }, {})).toMatchSnapshot();
     });
 
     it('errors for invalid `palette`', () => {
       expect(() =>
-        mixins.border({
-          size: 'sm',
-          // @ts-expect-error
-          palette: 'unknown',
-        }),
+        mixins.border(
+          {
+            size: 'sm',
+            // @ts-expect-error
+            palette: 'unknown',
+          },
+          {},
+        ),
       ).toThrowErrorMatchingSnapshot();
     });
 
     it('errors for invalid `shade`', () => {
       expect(() =>
-        mixins.border({
-          size: 'sm',
-          // @ts-expect-error
-          shade: '99',
-        }),
+        mixins.border(
+          {
+            size: 'sm',
+            // @ts-expect-error
+            shade: '99',
+          },
+          {},
+        ),
       ).toThrowErrorMatchingSnapshot();
     });
 
     it('errors for invalid `size`', () => {
       expect(() =>
-        mixins.border({
-          // @ts-expect-error
-          size: 'xl',
-        }),
+        mixins.border(
+          {
+            // @ts-expect-error
+            size: 'xl',
+          },
+          {},
+        ),
       ).toThrowErrorMatchingSnapshot();
     });
   });
@@ -72,16 +84,19 @@ describe('Mixins', () => {
   describe('foreground', () => {
     it('renders foreground', () => {
       expect(mixins.foreground()).toMatchSnapshot();
-      expect(mixins.foreground({ palette: 'success' })).toMatchSnapshot();
-      expect(mixins.foreground({ palette: 'warning' })).toMatchSnapshot();
+      expect(mixins.foreground({ palette: 'success' }, {})).toMatchSnapshot();
+      expect(mixins.foreground({ palette: 'warning' }, {})).toMatchSnapshot();
     });
 
     it('errors for invalid `palette`', () => {
       expect(() =>
-        mixins.foreground({
-          // @ts-expect-error
-          palette: 'unknown',
-        }),
+        mixins.foreground(
+          {
+            // @ts-expect-error
+            palette: 'unknown',
+          },
+          {},
+        ),
       ).toThrowErrorMatchingSnapshot();
     });
   });
@@ -103,16 +118,19 @@ describe('Mixins', () => {
   describe('heading', () => {
     it('renders heading', () => {
       expect(mixins.heading()).toMatchSnapshot();
-      expect(mixins.heading({ level: 3 })).toMatchSnapshot();
-      expect(mixins.heading({ level: 6 })).toMatchSnapshot();
+      expect(mixins.heading({ level: 3 }, {})).toMatchSnapshot();
+      expect(mixins.heading({ level: 6 }, {})).toMatchSnapshot();
     });
 
     it('errors for invalid `level`', () => {
       expect(() =>
-        mixins.heading({
-          // @ts-expect-error
-          level: 9,
-        }),
+        mixins.heading(
+          {
+            // @ts-expect-error
+            level: 9,
+          },
+          {},
+        ),
       ).toThrowErrorMatchingSnapshot();
     });
   });
@@ -120,7 +138,7 @@ describe('Mixins', () => {
   describe('reset', () => {
     it('renders reset button', () => {
       expect(mixins.resetButton()).toMatchSnapshot();
-      expect(mixins.resetButton({ flex: true })).toMatchSnapshot();
+      expect(mixins.resetButton({ flex: true }, {})).toMatchSnapshot();
     });
 
     it('renders reset input', () => {
@@ -149,36 +167,45 @@ describe('Mixins', () => {
   describe('shadow', () => {
     it('renders shadow', () => {
       expect(mixins.shadow()).toMatchSnapshot();
-      expect(mixins.shadow({ size: 'sm', palette: 'info' })).toMatchSnapshot();
-      expect(mixins.shadow({ size: 'lg', shade: '50' })).toMatchSnapshot();
+      expect(mixins.shadow({ size: 'sm', palette: 'info' }, {})).toMatchSnapshot();
+      expect(mixins.shadow({ size: 'lg', shade: '50' }, {})).toMatchSnapshot();
     });
 
     it('errors for invalid `palette`', () => {
       expect(() =>
-        mixins.shadow({
-          size: 'sm',
-          // @ts-expect-error
-          palette: 'unknown',
-        }),
+        mixins.shadow(
+          {
+            size: 'sm',
+            // @ts-expect-error
+            palette: 'unknown',
+          },
+          {},
+        ),
       ).toThrowErrorMatchingSnapshot();
     });
 
     it('errors for invalid `shade`', () => {
       expect(() =>
-        mixins.shadow({
-          size: 'sm',
-          // @ts-expect-error
-          shade: '99',
-        }),
+        mixins.shadow(
+          {
+            size: 'sm',
+            // @ts-expect-error
+            shade: '99',
+          },
+          {},
+        ),
       ).toThrowErrorMatchingSnapshot();
     });
 
     it('errors for invalid `size`', () => {
       expect(() =>
-        mixins.shadow({
-          // @ts-expect-error
-          size: 'xxl',
-        }),
+        mixins.shadow(
+          {
+            // @ts-expect-error
+            size: 'xxl',
+          },
+          {},
+        ),
       ).toThrowErrorMatchingSnapshot();
     });
   });
@@ -186,15 +213,18 @@ describe('Mixins', () => {
   describe('text', () => {
     it('renders text', () => {
       expect(mixins.text()).toMatchSnapshot();
-      expect(mixins.text({ size: 'lg' })).toMatchSnapshot();
+      expect(mixins.text({ size: 'lg' }, {})).toMatchSnapshot();
     });
 
     it('errors for invalid `size`', () => {
       expect(() =>
-        mixins.text({
-          // @ts-expect-error
-          size: 'xl',
-        }),
+        mixins.text(
+          {
+            // @ts-expect-error
+            size: 'xl',
+          },
+          {},
+        ),
       ).toThrowErrorMatchingSnapshot();
     });
 
@@ -215,26 +245,26 @@ describe('Mixins', () => {
     describe('box', () => {
       it('renders box', () => {
         expect(mixins.uiBox()).toMatchSnapshot();
-        expect(mixins.uiBox({ palette: 'brand' })).toMatchSnapshot();
+        expect(mixins.uiBox({ palette: 'brand' }, {})).toMatchSnapshot();
       });
 
       it('renders box without border', () => {
-        expect(mixins.uiBox({ border: false })).toMatchSnapshot();
+        expect(mixins.uiBox({ border: false }, {})).toMatchSnapshot();
       });
 
       it('renders box with custom border options', () => {
         expect(
-          mixins.uiBox({ border: { palette: 'success', size: 'lg' }, palette: 'danger' }),
+          mixins.uiBox({ border: { palette: 'success', size: 'lg' }, palette: 'danger' }, {}),
         ).toMatchSnapshot();
       });
 
       it('renders box without shadow', () => {
-        expect(mixins.uiBox({ palette: 'brand', shadow: false })).toMatchSnapshot();
+        expect(mixins.uiBox({ palette: 'brand', shadow: false }, {})).toMatchSnapshot();
       });
 
       it('renders box with custom shadow options', () => {
         expect(
-          mixins.uiBox({ palette: 'brand', shadow: { palette: 'info', shade: '00' } }),
+          mixins.uiBox({ palette: 'brand', shadow: { palette: 'info', shade: '00' } }, {}),
         ).toMatchSnapshot();
       });
     });
@@ -242,6 +272,6 @@ describe('Mixins', () => {
 
   it('renders interactive', () => {
     expect(mixins.uiInteractive()).toMatchSnapshot();
-    expect(mixins.uiInteractive({ palette: 'primary' })).toMatchSnapshot();
+    expect(mixins.uiInteractive({ palette: 'primary' }, {})).toMatchSnapshot();
   });
 });

--- a/packages/system/src/types.ts
+++ b/packages/system/src/types.ts
@@ -456,16 +456,20 @@ export type MixinTemplate<T extends object = object> = (options: T) => Rule;
 
 export type MixinTemplateMap = Record<string, MixinTemplate>;
 
-export type MixinUtil<T extends object = object> = (options?: T, properties?: Rule) => Rule;
+export interface MixinBuiltIn<T extends object = object> {
+  (options: T, rule: Rule): Rule;
+  (rule?: Rule): Rule;
+}
 
-export interface MixinUtils {
-  (name: string, options?: object, ...additionalRules: Rule[]): Rule;
+export interface MixinUtil<T extends object = object> {
+  (name: string, options: T, rule: Rule): Rule;
+  (name: string, rule?: Rule): Rule;
 }
 
 // OTHER
 
 export interface Utilities {
-  mixin: MixinUtils;
+  mixin: MixinUtil;
   token: TokenUtil;
   unit: UnitUtil;
   var: VarUtil;

--- a/packages/system/tests/Theme.test.ts
+++ b/packages/system/tests/Theme.test.ts
@@ -3,7 +3,11 @@
 import { Theme, Utilities } from '../src';
 import { design, lightTheme } from '../src/testing';
 
-function text(this: Utilities, { size = 'df' }: { size?: string }) {
+interface TextOptions {
+  size?: string;
+}
+
+function text(this: Utilities, { size = 'df' }: TextOptions) {
   return {
     color: this.var('palette-neutral-fg-base'),
     fontFamily: this.var('typography-font-text'),
@@ -18,7 +22,6 @@ describe('Theme', () => {
   beforeEach(() => {
     // Copy so we dont mutate the testing mock
     testTheme = lightTheme.extend({});
-
     testTheme.registerMixin('text', text);
   });
 
@@ -94,32 +97,12 @@ describe('Theme', () => {
     });
 
     it('can utilize the same options as the parent mixin', () => {
-      testTheme.extendMixin('text', ({ size }: { size?: string }) => ({
+      testTheme.extendMixin('text', ({ size }: TextOptions) => ({
         fontWeight: size === 'lg' ? 'bold' : 'normal',
       }));
 
       expect(testTheme.mixin('text')).toMatchSnapshot();
-      expect(testTheme.mixin('text', { size: 'lg' })).toMatchSnapshot();
-    });
-
-    it('will deep merge properties', () => {
-      testTheme.registerMixin('example', () => ({
-        display: 'block',
-        ':focus': {
-          color: 'red',
-        },
-      }));
-
-      testTheme.extendMixin('example', () => ({
-        ':focus': {
-          outline: 'none',
-        },
-      }));
-
-      expect(testTheme.mixin('example')[':focus']).toEqual({
-        color: 'red',
-        outline: 'none',
-      });
+      expect(testTheme.mixin('text', { size: 'lg' }, {})).toMatchSnapshot();
     });
   });
 
@@ -133,26 +116,35 @@ describe('Theme', () => {
       spy.mockRestore();
     });
 
+    it('returns base properties when no options or extra rule passed', () => {
+      expect(testTheme.mixin('text')).toMatchSnapshot();
+    });
+
+    it('returns merged properties when no options passed but an extra rule is passed', () => {
+      expect(
+        testTheme.mixin('text', {
+          fontSize: '60px',
+        }),
+      ).toMatchSnapshot();
+    });
+
+    it('returns merged and customized properties when options and extra rule passed', () => {
+      expect(
+        testTheme.mixin(
+          'text',
+          { size: 'large' },
+          {
+            fontSize: '60px',
+          },
+        ),
+      ).toMatchSnapshot();
+    });
+
     it('merges multiple templates with base mixin', () => {
       testTheme.extendMixin('text', () => ({ fontWeight: 'bold' }));
       testTheme.extendMixin('text', () => ({ fontSize: '24px' }));
 
       expect(testTheme.mixin('text')).toMatchSnapshot();
-    });
-
-    it('merges additional rules with base mixin', () => {
-      expect(
-        testTheme.mixin(
-          'text',
-          {},
-          {
-            fontWeight: 'bold',
-          },
-          {
-            fontSize: '24px',
-          },
-        ),
-      ).toMatchSnapshot();
     });
 
     it('merges templates and rules with base mixin', () => {

--- a/packages/system/tests/__snapshots__/Theme.test.ts.snap
+++ b/packages/system/tests/__snapshots__/Theme.test.ts.snap
@@ -51,16 +51,6 @@ Object {
 }
 `;
 
-exports[`Theme mixin() merges additional rules with base mixin 1`] = `
-Object {
-  "color": "var(--palette-neutral-fg-base)",
-  "fontFamily": "var(--typography-font-text)",
-  "fontSize": "24px",
-  "fontWeight": "bold",
-  "lineHeight": "var(--text-df-line-height)",
-}
-`;
-
 exports[`Theme mixin() merges multiple templates with base mixin 1`] = `
 Object {
   "color": "var(--palette-neutral-fg-base)",
@@ -77,6 +67,33 @@ Object {
   "fontFamily": "var(--typography-font-text)",
   "fontSize": "24px",
   "fontWeight": "bold",
+  "lineHeight": "var(--text-df-line-height)",
+}
+`;
+
+exports[`Theme mixin() returns base properties when no options or extra rule passed 1`] = `
+Object {
+  "color": "var(--palette-neutral-fg-base)",
+  "fontFamily": "var(--typography-font-text)",
+  "fontSize": "var(--text-df-size)",
+  "lineHeight": "var(--text-df-line-height)",
+}
+`;
+
+exports[`Theme mixin() returns merged and customized properties when options and extra rule passed 1`] = `
+Object {
+  "color": "var(--palette-neutral-fg-base)",
+  "fontFamily": "var(--typography-font-text)",
+  "fontSize": "60px",
+  "lineHeight": "var(--text-large-line-height)",
+}
+`;
+
+exports[`Theme mixin() returns merged properties when no options passed but an extra rule is passed 1`] = `
+Object {
+  "color": "var(--palette-neutral-fg-base)",
+  "fontFamily": "var(--typography-font-text)",
+  "fontSize": "60px",
   "lineHeight": "var(--text-df-line-height)",
 }
 `;


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/aesthetic-suite/framework/blob/main/CONTRIBUTING.md
-->

<!-- If fixing an issue, uncomment the following and include a link/issue number. -->

<!-- Fixes issue # -->

## Summary

Turns out having to always provide the options object to pass a rule to a mixin is annoying, so let's reverse it.

## Screenshots

<!-- If applicable, screenshots or videos of the change working correctly. -->

## Checklist

- [x] Build passes with `yarn test`.
- [x] Code is formatted with `yarn format`.
- [x] Tests have been added for my changes.
- [x] Code coverage for my change is 100%.
- [x] Documentation has been updated for my changes.
