### PR TITLE
internal: Rework how selectors are defined.

### DIFF
--- a/packages/addon-vendor/src/index.ts
+++ b/packages/addon-vendor/src/index.ts
@@ -4,9 +4,9 @@
  */
 
 import prefix from './prefix';
-import prefixSelector from './prefixSelector';
+import prefixSelectors from './prefixSelectors';
 
 export default {
   prefix,
-  prefixSelector,
+  prefixSelectors,
 };

--- a/packages/addon-vendor/src/prefixSelectors.ts
+++ b/packages/addon-vendor/src/prefixSelectors.ts
@@ -1,8 +1,9 @@
 import { CSS } from '@aesthetic/types';
+import { arrayReduce } from '@aesthetic/utils';
 import getPrefixesFromMask from './getPrefixesFromMask';
 import { selectorMapping } from './data';
 
-export default function prefixSelector(selector: string, rule: CSS): CSS {
+export function prefixSelector(selector: string, rule: CSS): CSS {
   const mask = selectorMapping[selector];
   let output = '';
 
@@ -22,4 +23,8 @@ export default function prefixSelector(selector: string, rule: CSS): CSS {
   output += rule;
 
   return output;
+}
+
+export default function prefixSelectors(selectors: string[], rule: CSS): CSS {
+  return selectors.reduce((css, selector) => prefixSelector(selector, css), rule);
 }

--- a/packages/addon-vendor/src/prefixSelectors.ts
+++ b/packages/addon-vendor/src/prefixSelectors.ts
@@ -1,5 +1,4 @@
 import { CSS } from '@aesthetic/types';
-import { arrayReduce } from '@aesthetic/utils';
 import getPrefixesFromMask from './getPrefixesFromMask';
 import { selectorMapping } from './data';
 

--- a/packages/addon-vendor/tests/prefixSelectors.test.ts
+++ b/packages/addon-vendor/tests/prefixSelectors.test.ts
@@ -1,4 +1,4 @@
-import prefixSelector from '../src/prefixSelector';
+import prefixSelectors, { prefixSelector } from '../src/prefixSelectors';
 
 describe('prefixSelector()', () => {
   it('doesnt prefix for unsupported selector', () => {
@@ -22,6 +22,16 @@ describe('prefixSelector()', () => {
   it('prefixes a supported pseudo element', () => {
     expect(prefixSelector('::backdrop', '.a::backdrop { background:black; }')).toBe(
       '.a::-ms-backdrop { background:black; }.a::-webkit-backdrop { background:black; }.a::backdrop { background:black; }',
+    );
+  });
+});
+
+describe('prefixSelectors()', () => {
+  it('prefixes multiple selectors', () => {
+    expect(
+      prefixSelectors([':fullscreen', '::backdrop'], '.d:fullscreen::backdrop { display:none; }'),
+    ).toBe(
+      '.d:-ms-fullscreen::-ms-backdrop { display:none; }.d:-webkit-fullscreen::backdrop { display:none; }.d:fullscreen::backdrop { display:none; }.d:-ms-fullscreen::-webkit-backdrop { display:none; }.d:-webkit-fullscreen::backdrop { display:none; }.d:fullscreen::backdrop { display:none; }.d:-ms-fullscreen::backdrop { display:none; }.d:-webkit-fullscreen::backdrop { display:none; }.d:fullscreen::backdrop { display:none; }',
     );
   });
 });

--- a/packages/core/src/StyleSheet.ts
+++ b/packages/core/src/StyleSheet.ts
@@ -27,7 +27,6 @@ function createCacheKey(params: Required<SheetParams>, type: string): string | n
 
 function groupSelectorsAndConditions(selectors: string[]) {
   const conditions: string[] = [];
-  let selector = '';
   let valid = true;
 
   arrayLoop(selectors, (value) => {
@@ -38,14 +37,11 @@ function groupSelectorsAndConditions(selectors: string[]) {
       valid = false;
     } else if (value.slice(0, 6) === '@media' || value.slice(0, 9) === '@supports') {
       conditions.push(value);
-    } else {
-      selector += value;
     }
   });
 
   return {
     conditions: conditions.length === 0 ? undefined : [],
-    selector,
     valid,
   };
 }
@@ -204,7 +200,8 @@ export default class StyleSheet<Result, Factory extends BaseSheetFactory> {
         return engine.renderKeyframes(keyframes.toObject(), animationName, getRenderOptions());
       },
       onProperty(block, property, value) {
-        const { conditions, selector, valid } = groupSelectorsAndConditions(block.getSelectors());
+        const selectors = block.getSelectors();
+        const { conditions, valid } = groupSelectorsAndConditions(block.getSelectors());
 
         if (valid) {
           block.addClassName(
@@ -214,7 +211,7 @@ export default class StyleSheet<Result, Factory extends BaseSheetFactory> {
                 value as string,
                 getRenderOptions({
                   conditions,
-                  selector,
+                  selectors,
                 }),
               ),
             ),

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -22,7 +22,7 @@ import StyleSheet from './StyleSheet';
 export { GlobalStyleSheet, LocalStyleSheet, LocalBlock, CustomProperties };
 
 // And add aliases too
-export type GlobalStyles = GlobalStyleSheet;
+export type ThemeStyles = GlobalStyleSheet;
 export type ComponentStyles = LocalStyleSheet;
 export type ElementStyles = LocalBlock;
 

--- a/packages/style/src/client/hydration.ts
+++ b/packages/style/src/client/hydration.ts
@@ -18,17 +18,16 @@ const FONT_FAMILY = /font-family:([^;]+)/;
 const IMPORT_URL = /url\(["']?([^)]+)["']?\)/;
 
 function addRuleToCache(engine: StyleEngine, rule: string, rank: number, conditions?: string[]) {
-  const [, className, selector = '', property, value] = rule.match(RULE_PATTERN)!;
-  const cacheKey = createCacheKey(
-    property,
-    // Has trailing semi-colon
-    value.slice(0, -1),
-    {
-      conditions,
-      // Has trailing spaces
-      selector: selector.trim(),
-    },
-  );
+  const [, className, rawSelector = '', property, rawValue] = rule.match(RULE_PATTERN)!;
+  // Has trailing spaces
+  const selector = rawSelector.trim();
+  // Has trailing semi-colon
+  const value = rawValue.slice(0, -1);
+
+  const cacheKey = createCacheKey(property, value, {
+    conditions,
+    selectors: selector ? [selector] : undefined,
+  });
 
   engine.cacheManager.write(cacheKey, {
     className,

--- a/packages/style/src/common/cache.ts
+++ b/packages/style/src/common/cache.ts
@@ -10,12 +10,12 @@ import {
 export function createCacheKey(
   property: string,
   value: Value | ValueWithFallbacks,
-  { selector, conditions }: RenderOptions,
+  { selectors, conditions }: RenderOptions,
 ): string {
   let key = `${property}:${value}`;
 
-  if (selector) {
-    key += `:${selector}`;
+  if (selectors && selectors.length > 0) {
+    key += `:${selectors.join(':')}`;
   }
 
   if (conditions && conditions.length > 0) {

--- a/packages/style/src/common/engine.ts
+++ b/packages/style/src/common/engine.ts
@@ -81,8 +81,8 @@ function insertStyles(
 
     // Insert rule and return a rank (insert index)
     const rank = sheetManager.insertRule(
-      options.selector && options.vendor && vendorPrefixer
-        ? vendorPrefixer.prefixSelector(options.selector, css)
+      options.selectors && options.vendor && vendorPrefixer
+        ? vendorPrefixer.prefixSelectors(options.selectors, css)
         : css,
       options,
     );
@@ -116,9 +116,13 @@ function procesNested(
 
     // Selectors
   } else if (isNestedSelector(property)) {
-    options.selector = property;
+    if (!options.selectors) {
+      options.selectors = [];
+    }
+
+    options.selectors.push(property);
     className = render();
-    options.selector = undefined;
+    options.selectors.pop();
 
     // Unknown
   } else if (__DEV__) {

--- a/packages/style/src/common/engine.ts
+++ b/packages/style/src/common/engine.ts
@@ -120,6 +120,17 @@ function procesNested(
       options.selectors = [];
     }
 
+    if (__DEV__) {
+      if (property.includes(', ')) {
+        // eslint-disable-next-line no-console
+        console.warn(
+          `Multiple selectors separated by a comma are not supported, found "${property}".`,
+        );
+
+        return className;
+      }
+    }
+
     options.selectors.push(property);
     className = render();
     options.selectors.pop();

--- a/packages/style/src/common/syntax.ts
+++ b/packages/style/src/common/syntax.ts
@@ -58,9 +58,9 @@ export function formatDeclarationBlock(properties: Record<string, Value>): CSS {
 export function formatRule(
   className: ClassName,
   block: CSS,
-  { conditions, selector = '' }: RenderOptions,
+  { conditions, selectors }: RenderOptions,
 ): CSS {
-  let rule = `.${className}${selector} { ${block} }`;
+  let rule = `.${className}${selectors ? selectors.join('') : ''} { ${block} }`;
 
   // Server-side rendering recursively creates CSS rules to collapse
   // conditionals to their smallest representation, so we need to avoid

--- a/packages/style/tests/__snapshots__/styles.test.ts.snap
+++ b/packages/style/tests/__snapshots__/styles.test.ts.snap
@@ -98,6 +98,8 @@ exports[`Engine renderRule() can nest conditionals infinitely 1`] = `".a {margin
 
 exports[`Engine renderRule() can nest conditionals infinitely 2`] = `"@media (width: 500px) {.b {margin: 10px;}}@media (width: 500px) {.c:hover {color: red;}}@media (width: 500px) {@media (width: 350px) {@supports (color: blue) {.d {color: blue;}}}}@media (width: 500px) {@media (width: 350px) {@supports (color: blue) {.e:focus {color: darkblue;}}}}"`;
 
+exports[`Engine renderRule() can nest selectors infinitely 1`] = `".a {width: 100%;}.b {max-width: 100%;}.c {margin: 0;}.d {padding: 0;}.e {background-color: #fff;}.f {border: 1px solid #ccc;}.g {border-collapse: collapse;}.h {border-spacing: 0;}.i> thead {display: table-head;}.j> thead> tr {background-color: #eee;}.k> thead> tr> th {border: 1px solid #ccc;}.l> thead> tr> th {padding: 8px;}.m> thead> tr> th {text-align: center;}.n> thead> tr> th> span {font-weight: bold;}.o> thead> tr> th> a {text-decoration: underline;}.p> thead> tr> td {border: 1px solid #ccc;}.q> thead> tr> td {padding: 8px;}.r> thead> tr> td {text-align: left;}"`;
+
 exports[`Engine renderRule() generates a deterministic class name for each property 1`] = `".cl8qkup {margin: 0;}.c1hykqr2 {cursor: pointer;}"`;
 
 exports[`Engine renderRule() generates a unique class name for each property 1`] = `".a {margin: 0;}.b {padding: 6px 12px;}.c {border: 1px solid #2e6da4;}.d {border-radius: 4px;}.e {display: inline-block;}.f {cursor: pointer;}.g {font-family: Roboto;}.h {font-weight: normal;}.i {line-height: normal;}.j {white-space: nowrap;}.k {text-decoration: none;}.l {text-align: left;}.m {background-color: #337ab7;}.n {vertical-align: middle;}.o {color: rgba(0, 0, 0, 0);}.p {animation-name: fade;}.q {animation-duration: .3s;}"`;
@@ -117,6 +119,8 @@ exports[`Engine renderRule() inserts into the appropriate style sheets 1`] = `".
 exports[`Engine renderRule() inserts into the appropriate style sheets 2`] = `"@media (prefers-color-scheme: dark) {.b {background: black;}}"`;
 
 exports[`Engine renderRule() logs a warning for invalid values 1`] = `""`;
+
+exports[`Engine renderRule() logs a warning for multiple selectors 1`] = `".a {display: table;}"`;
 
 exports[`Engine renderRule() logs a warning for unknown nested selector 1`] = `".a {background: white;}"`;
 

--- a/packages/style/tests/styles.test.ts
+++ b/packages/style/tests/styles.test.ts
@@ -109,7 +109,7 @@ describe('Engine', () => {
 
       // Selector prefixing
       engine.renderDeclaration('display', 'none', {
-        selector: ':fullscreen',
+        selectors: [':fullscreen'],
         vendor: true,
       });
 
@@ -124,9 +124,9 @@ describe('Engine', () => {
 
     describe('selectors', () => {
       it('supports selectors', () => {
-        engine.renderDeclaration('color', 'green', { selector: ':hover' });
-        engine.renderDeclaration('color', 'red', { selector: '[disabled]' });
-        engine.renderDeclaration('color', 'blue', { selector: ':nth-child(2)' });
+        engine.renderDeclaration('color', 'green', { selectors: [':hover'] });
+        engine.renderDeclaration('color', 'red', { selectors: ['[disabled]'] });
+        engine.renderDeclaration('color', 'blue', { selectors: [':nth-child(2)'] });
 
         expect(getRenderedStyles('standard')).toMatchSnapshot();
       });
@@ -150,7 +150,7 @@ describe('Engine', () => {
       it('supports conditionals with selectors', () => {
         engine.renderDeclaration('color', 'green', {
           conditions: ['@media (max-size: 100px)'],
-          selector: ':focus',
+          selectors: [':focus'],
         });
 
         expect(getRenderedStyles('conditions')).toMatchSnapshot();
@@ -652,7 +652,7 @@ describe('Engine', () => {
           },
         });
         const classNameB = engine.renderDeclaration('backgroundColor', '#000', {
-          selector: '[disabled]',
+          selectors: ['[disabled]'],
         });
 
         expect(classNameA).toBe('a');
@@ -662,7 +662,7 @@ describe('Engine', () => {
 
       it('supports complex attribute selectors', () => {
         engine.renderDeclaration('backgroundColor', '#286090', {
-          selector: '[href*="example"]',
+          selectors: ['[href*="example"]'],
         });
 
         expect(getRenderedStyles('standard')).toMatchSnapshot();
@@ -693,7 +693,7 @@ describe('Engine', () => {
           },
         });
         const classNameB = engine.renderDeclaration('backgroundColor', '#000', {
-          selector: ':focus',
+          selectors: [':focus'],
         });
 
         expect(classNameA).toBe('a');
@@ -703,7 +703,7 @@ describe('Engine', () => {
 
       it('supports complex attribute selectors', () => {
         engine.renderDeclaration('color', 'white', {
-          selector: ':nth-last-of-type(4n)',
+          selectors: [':nth-last-of-type(4n)'],
         });
 
         expect(getRenderedStyles('standard')).toMatchSnapshot();
@@ -739,7 +739,7 @@ describe('Engine', () => {
           },
         });
         const classNameB = engine.renderDeclaration('backgroundColor', '#000', {
-          selector: '+ div',
+          selectors: ['+ div'],
         });
 
         expect(classNameA).toBe('a');
@@ -749,7 +749,7 @@ describe('Engine', () => {
 
       it('supports complex attribute selectors', () => {
         engine.renderDeclaration('color', 'white', {
-          selector: ':first-of-type + li',
+          selectors: [':first-of-type + li'],
         });
 
         expect(getRenderedStyles('standard')).toMatchSnapshot();

--- a/packages/style/tests/styles.test.ts
+++ b/packages/style/tests/styles.test.ts
@@ -494,6 +494,63 @@ describe('Engine', () => {
       expect(getRenderedStyles('conditions')).toMatchSnapshot();
     });
 
+    it('can nest selectors infinitely', () => {
+      engine.renderRule({
+        width: '100%',
+        maxWidth: '100%',
+        margin: 0,
+        padding: 0,
+        backgroundColor: '#fff',
+        border: '1px solid #ccc',
+        borderCollapse: 'collapse',
+        borderSpacing: 0,
+        '> thead': {
+          display: 'table-head',
+          '> tr': {
+            backgroundColor: '#eee',
+            '> th': {
+              border: '1px solid #ccc',
+              padding: 8,
+              textAlign: 'center',
+              '> span': {
+                fontWeight: 'bold',
+              },
+              '> a': {
+                textDecoration: 'underline',
+              },
+            },
+            '> td': {
+              border: '1px solid #ccc',
+              padding: 8,
+              textAlign: 'left',
+            },
+          },
+        },
+      });
+
+      expect(getRenderedStyles('standard')).toMatchSnapshot();
+    });
+
+    it('logs a warning for multiple selectors', () => {
+      const spy = jest.spyOn(console, 'warn').mockImplementation();
+
+      engine.renderRule({
+        display: 'table',
+        '> td, > th': {
+          padding: 0,
+        },
+      });
+
+      expect(spy).toHaveBeenCalledWith(
+        'Multiple selectors separated by a comma are not supported, found "> td, > th".',
+      );
+
+      // Should not render!
+      expect(getRenderedStyles('standard')).toMatchSnapshot();
+
+      spy.mockRestore();
+    });
+
     it('ignores invalid values', () => {
       const spy = jest.spyOn(console, 'warn').mockImplementation();
 

--- a/packages/types/src/engine.ts
+++ b/packages/types/src/engine.ts
@@ -65,7 +65,7 @@ export interface SheetManager {
 
 export interface VendorPrefixer {
   prefix: (property: string, value: string) => Record<string, string>;
-  prefixSelector: (selector: string, rule: CSS) => CSS;
+  prefixSelectors: (selectors: string[], rule: CSS) => CSS;
 }
 
 // STYLE ENGINE
@@ -73,15 +73,15 @@ export interface VendorPrefixer {
 export type RankCache = Record<string, number>;
 
 export interface RenderOptions {
-  deterministic?: boolean;
-  direction?: Direction;
   className?: ClassName;
   conditions?: string[];
+  deterministic?: boolean;
+  direction?: Direction;
   rankings?: RankCache;
+  selectors?: string[];
   type?: SheetType;
   unit?: Unit;
   vendor?: boolean;
-  selector?: string;
 }
 
 export interface EngineOptions {


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/aesthetic-suite/framework/blob/main/CONTRIBUTING.md
-->

<!-- If fixing an issue, uncomment the following and include a link/issue number. -->

<!-- Fixes issue # -->

## Summary

Noticed that deeply nested selectors was not working correctly (an example in the test), so I had to rework them to support an array like `conditions` do.

## Screenshots

<!-- If applicable, screenshots or videos of the change working correctly. -->

## Checklist

- [x] Build passes with `yarn test`.
- [x] Code is formatted with `yarn format`.
- [x] Tests have been added for my changes.
- [x] Code coverage for my change is 100%.
- [x] Documentation has been updated for my changes.
