### PR TITLE
new: Improve SSS and core interoperability.

### DIFF
--- a/packages/core/benchmarks/local-sheet-parser.js
+++ b/packages/core/benchmarks/local-sheet-parser.js
@@ -83,35 +83,6 @@ function createStyles() {
   };
 }
 
-function groupSelectorsAndConditions(selectors) {
-  let media = '';
-  let selector = '';
-  let supports = '';
-  let valid = true;
-
-  arrayLoop(selectors, (value) => {
-    const part = value.slice(0, 10);
-
-    if (part === '@keyframes' || part === '@font-face') {
-      // istanbul ignore next
-      valid = false;
-    } else if (value.slice(0, 6) === '@media') {
-      media = joinQueries(media, value.slice(6).trim());
-    } else if (value.slice(0, 9) === '@supports') {
-      supports = joinQueries(supports, value.slice(9).trim());
-    } else {
-      selector += value;
-    }
-  });
-
-  return {
-    media,
-    selector,
-    supports,
-    valid,
-  };
-}
-
 // Test parsing the entire block before injection
 function parseAsBlock(styles) {
   const classNames = {};
@@ -169,20 +140,12 @@ function parseAsDeclaration(styles) {
       return engine2.renderKeyframes(keyframes.toObject(), animationName);
     },
     onProperty(block, key, value) {
-      const { media, selector, supports, valid } = groupSelectorsAndConditions(
-        block.getSelectors(),
-      );
-
-      if (!valid) {
-        return;
-      }
-
       block.addClassName(
         engine2.renderDeclaration(key, value, {
-          media,
+          media: block.media,
           rankings,
-          selector,
-          supports,
+          selector: block.selector,
+          supports: block.supports,
         }),
       );
     },

--- a/packages/core/src/StyleSheet.ts
+++ b/packages/core/src/StyleSheet.ts
@@ -1,5 +1,3 @@
-/* eslint-disable no-magic-numbers */
-
 import { parse } from '@aesthetic/sss';
 import { ColorScheme, ContrastLevel, Theme } from '@aesthetic/system';
 import { Property, Rule, RenderOptions, Engine, ClassName } from '@aesthetic/types';

--- a/packages/core/src/StyleSheet.ts
+++ b/packages/core/src/StyleSheet.ts
@@ -3,7 +3,7 @@
 import { parse } from '@aesthetic/sss';
 import { ColorScheme, ContrastLevel, Theme } from '@aesthetic/system';
 import { Property, Rule, RenderOptions, Engine, ClassName } from '@aesthetic/types';
-import { arrayLoop, deepMerge, joinQueries, objectLoop } from '@aesthetic/utils';
+import { deepMerge, objectLoop } from '@aesthetic/utils';
 import {
   BaseSheetFactory,
   RenderResult,
@@ -23,35 +23,6 @@ function createCacheKey(params: Required<SheetParams>, type: string): string | n
   });
 
   return key;
-}
-
-function groupSelectorsAndConditions(selectors: string[]) {
-  let media = '';
-  let selector = '';
-  let supports = '';
-  let valid = true;
-
-  arrayLoop(selectors, (value) => {
-    const part = value.slice(0, 10);
-
-    if (part === '@keyframes' || part === '@font-face') {
-      // istanbul ignore next
-      valid = false;
-    } else if (value.slice(0, 6) === '@media') {
-      media = joinQueries(media, value.slice(6).trim());
-    } else if (value.slice(0, 9) === '@supports') {
-      supports = joinQueries(supports, value.slice(9).trim());
-    } else {
-      selector += value;
-    }
-  });
-
-  return {
-    media,
-    selector,
-    supports,
-    valid,
-  };
 }
 
 export default class StyleSheet<Result, Factory extends BaseSheetFactory> {
@@ -205,23 +176,17 @@ export default class StyleSheet<Result, Factory extends BaseSheetFactory> {
         return engine.renderKeyframes(keyframes.toObject(), animationName, renderOptions);
       },
       onProperty(block, property, value) {
-        const { media, selector, supports, valid } = groupSelectorsAndConditions(
-          block.getSelectors(),
+        block.addClassName(
+          String(
+            engine.renderDeclaration(property as Property, value as string, {
+              ...renderOptions,
+              media: block.media,
+              rankings,
+              selector: block.selector,
+              supports: block.supports,
+            }),
+          ),
         );
-
-        if (valid) {
-          block.addClassName(
-            String(
-              engine.renderDeclaration(property as Property, value as string, {
-                ...renderOptions,
-                media,
-                rankings,
-                selector,
-                supports,
-              }),
-            ),
-          );
-        }
       },
       onRoot: (block) => {
         addClassToMap(

--- a/packages/sss/.eslintrc
+++ b/packages/sss/.eslintrc
@@ -1,5 +1,6 @@
 {
   "rules": {
+    "no-param-reassign": "off",
     "compat/compat": "off",
     "import/no-unresolved": "off"
   }

--- a/packages/sss/src/Block.ts
+++ b/packages/sss/src/Block.ts
@@ -1,5 +1,3 @@
-/* eslint-disable no-dupe-class-members, lines-between-class-members */
-
 import { ClassName, Value } from '@aesthetic/types';
 import { objectLoop } from '@aesthetic/utils';
 
@@ -43,28 +41,7 @@ export default class Block<T extends object = object> {
       this.nested[block.id] = block;
     }
 
-    // eslint-disable-next-line no-param-reassign
     block.parent = this;
-
-    return block;
-  }
-
-  addProperty<K extends keyof T>(key: K, value: T[K]): this;
-  addProperty(key: string, value: Value): this;
-  addProperty(key: string, value: unknown): this {
-    this.properties[key] = value as string;
-
-    return this;
-  }
-
-  addVariable(key: string, value: Value): this {
-    this.variables[key] = value;
-
-    return this;
-  }
-
-  addVariant(type: string, block: Block<T>): Block<T> {
-    this.variants[type] = block;
 
     return block;
   }

--- a/packages/sss/src/Block.ts
+++ b/packages/sss/src/Block.ts
@@ -1,5 +1,5 @@
 import { ClassName, Value } from '@aesthetic/types';
-import { objectLoop } from '@aesthetic/utils';
+import { joinQueries, objectLoop } from '@aesthetic/utils';
 
 export default class Block<T extends object = object> {
   className: string = '';
@@ -34,16 +34,19 @@ export default class Block<T extends object = object> {
     }
   }
 
-  nest(block: Block<T>): Block<T> {
-    if (this.nested[block.id]) {
-      this.nested[block.id].merge(block);
+  nest(child: Block<T>): Block<T> {
+    if (this.nested[child.id]) {
+      this.nested[child.id].merge(child);
     } else {
-      this.nested[block.id] = block;
+      this.nested[child.id] = child;
     }
 
-    block.parent = this;
+    child.parent = this;
+    child.media = joinQueries(this.media, child.media);
+    child.selector = this.selector + child.selector;
+    child.supports = joinQueries(this.supports, child.supports);
 
-    return block;
+    return child;
   }
 
   merge(block: Block<T>): this {

--- a/packages/sss/src/Block.ts
+++ b/packages/sss/src/Block.ts
@@ -34,7 +34,7 @@ export default class Block<T extends object = object> {
     }
   }
 
-  addNested(block: Block<T>): Block<T> {
+  nest(block: Block<T>): Block<T> {
     if (this.nested[block.id]) {
       this.nested[block.id].merge(block);
     } else {
@@ -50,7 +50,7 @@ export default class Block<T extends object = object> {
     Object.assign(this.properties, block.properties);
 
     objectLoop(block.nested, (nested) => {
-      this.addNested(nested);
+      this.nest(nested);
     });
 
     return this;

--- a/packages/sss/src/Block.ts
+++ b/packages/sss/src/Block.ts
@@ -6,20 +6,26 @@ import { objectLoop } from '@aesthetic/utils';
 export default class Block<T extends object = object> {
   className: string = '';
 
+  media: string = '';
+
   readonly nested: Record<string, Block<T>> = {};
 
   parent?: Block<T>;
 
   readonly properties: Record<string, Value> = {};
 
-  readonly selector: string;
+  readonly id: string;
+
+  selector: string = '';
+
+  supports: string = '';
 
   readonly variables: Record<string, Value> = {};
 
   readonly variants: Record<string, Block<T>> = {};
 
-  constructor(selector: string = '') {
-    this.selector = selector;
+  constructor(id: string = '') {
+    this.id = id;
   }
 
   addClassName(name: ClassName) {
@@ -31,10 +37,10 @@ export default class Block<T extends object = object> {
   }
 
   addNested(block: Block<T>): Block<T> {
-    if (this.nested[block.selector]) {
-      this.nested[block.selector].merge(block);
+    if (this.nested[block.id]) {
+      this.nested[block.id].merge(block);
     } else {
-      this.nested[block.selector] = block;
+      this.nested[block.id] = block;
     }
 
     // eslint-disable-next-line no-param-reassign
@@ -61,21 +67,6 @@ export default class Block<T extends object = object> {
     this.variants[type] = block;
 
     return block;
-  }
-
-  getSelectors(): string[] {
-    const selectors: string[] = [];
-    let block: Block<T> | undefined = this;
-
-    while (block) {
-      if (block.selector) {
-        selectors.unshift(block.selector);
-      }
-
-      block = block.parent;
-    }
-
-    return selectors;
   }
 
   merge(block: Block<T>): this {

--- a/packages/sss/src/helpers/createQueue.ts
+++ b/packages/sss/src/helpers/createQueue.ts
@@ -14,7 +14,6 @@ export default function createQueue(options: ParserOptions<object>) {
         items.push(() => callback(value, options));
       }
 
-      // eslint-disable-next-line no-param-reassign
       delete obj[key];
     },
     process() {

--- a/packages/sss/src/helpers/setupDefaultOptions.ts
+++ b/packages/sss/src/helpers/setupDefaultOptions.ts
@@ -1,5 +1,3 @@
-/* eslint-disable no-param-reassign */
-
 import { toArray } from '@aesthetic/utils';
 import parseFontFace from '../parsers/parseFontFace';
 import parseKeyframes from '../parsers/parseKeyframes';

--- a/packages/sss/src/parsers/parseBlock.ts
+++ b/packages/sss/src/parsers/parseBlock.ts
@@ -13,7 +13,7 @@ export default function parseBlock<T extends object>(
   emit: boolean = true,
 ): Block<T> {
   if (__DEV__) {
-    validateDeclarationBlock(object, parent.selector);
+    validateDeclarationBlock(object, parent.id);
   }
 
   objectLoop(object, (value, key) => {

--- a/packages/sss/src/parsers/parseConditionalBlock.ts
+++ b/packages/sss/src/parsers/parseConditionalBlock.ts
@@ -1,4 +1,4 @@
-import { joinQueries, objectLoop } from '@aesthetic/utils';
+import { objectLoop } from '@aesthetic/utils';
 import Block from '../Block';
 import validateDeclarations from '../helpers/validateDeclarations';
 import { ParserOptions, LocalBlockMap } from '../types';
@@ -16,8 +16,7 @@ export default function parseConditionalBlock<T extends object>(
 
   objectLoop(conditions, (object, condition) => {
     const block = new Block(`@${type} ${condition}`);
-
-    block[type] = joinQueries(parent[type], condition);
+    block[type] = condition;
 
     const nestedBlock = parseLocalBlock(parent.nest(block), object, options);
 

--- a/packages/sss/src/parsers/parseConditionalBlock.ts
+++ b/packages/sss/src/parsers/parseConditionalBlock.ts
@@ -19,7 +19,7 @@ export default function parseConditionalBlock<T extends object>(
 
     block[type] = joinQueries(parent[type], condition);
 
-    const nestedBlock = parseLocalBlock(parent.addNested(block), object, options);
+    const nestedBlock = parseLocalBlock(parent.nest(block), object, options);
 
     if (type === 'media') {
       options.onMedia?.(parent, condition, nestedBlock);

--- a/packages/sss/src/parsers/parseConditionalBlock.ts
+++ b/packages/sss/src/parsers/parseConditionalBlock.ts
@@ -1,4 +1,4 @@
-import { objectLoop } from '@aesthetic/utils';
+import { joinQueries, objectLoop } from '@aesthetic/utils';
 import Block from '../Block';
 import validateDeclarations from '../helpers/validateDeclarations';
 import { ParserOptions, LocalBlockMap } from '../types';
@@ -15,11 +15,11 @@ export default function parseConditionalBlock<T extends object>(
   }
 
   objectLoop(conditions, (object, condition) => {
-    const nestedBlock = parseLocalBlock(
-      parent.addNested(new Block(`@${type} ${condition}`)),
-      object,
-      options,
-    );
+    const block = new Block(`@${type} ${condition}`);
+
+    block[type] = joinQueries(parent[type], condition);
+
+    const nestedBlock = parseLocalBlock(parent.addNested(block), object, options);
 
     if (type === 'media') {
       options.onMedia?.(parent, condition, nestedBlock);

--- a/packages/sss/src/parsers/parseFallbacks.ts
+++ b/packages/sss/src/parsers/parseFallbacks.ts
@@ -21,7 +21,7 @@ export default function parseFallbacks<T extends object>(
       // but the style renderer does. This is the only use case for arrays,
       // so let's just ignore it here for type safety everywhere else.
       // @ts-expect-error
-      parent.addProperty(prop, [...values, current]);
+      parent.properties[prop] = [...values, current];
 
       options.onFallback?.(parent, prop, values);
     }

--- a/packages/sss/src/parsers/parseKeyframes.ts
+++ b/packages/sss/src/parsers/parseKeyframes.ts
@@ -9,10 +9,10 @@ export default function parseKeyframes<T extends object>(
   animationName: string,
   options: ParserOptions<T>,
 ): string {
-  const keyframes = new Block<T>(`@keyframes`);
+  const keyframes = new Block<T>('@keyframes');
 
   if (__DEV__) {
-    validateDeclarationBlock(object, keyframes.selector);
+    validateDeclarationBlock(object, keyframes.id);
   }
 
   // from, to, and percent keys aren't easily detectable

--- a/packages/sss/src/parsers/parseKeyframes.ts
+++ b/packages/sss/src/parsers/parseKeyframes.ts
@@ -18,7 +18,7 @@ export default function parseKeyframes<T extends object>(
   // from, to, and percent keys aren't easily detectable
   objectLoop(object, (value, key) => {
     if (value !== undefined) {
-      parseBlock(keyframes.addNested(new Block(key)), value, options, false);
+      parseBlock(keyframes.nest(new Block(key)), value, options, false);
     }
   });
 

--- a/packages/sss/src/parsers/parseLocalBlock.ts
+++ b/packages/sss/src/parsers/parseLocalBlock.ts
@@ -17,7 +17,7 @@ export default function parseLocalBlock<T extends object>(
   options: ParserOptions<T>,
 ): Block<T> {
   if (__DEV__) {
-    validateDeclarationBlock(object, parent.selector);
+    validateDeclarationBlock(object, parent.id);
   }
 
   const props = { ...object };

--- a/packages/sss/src/parsers/parseProperty.ts
+++ b/packages/sss/src/parsers/parseProperty.ts
@@ -11,7 +11,7 @@ export default function parseProperty<T extends object>(
 ) {
   const addHandler: AddPropertyCallback = (p, v) => {
     if (v !== undefined) {
-      parent.addProperty(p, v);
+      parent.properties[p] = v;
 
       if (emit) {
         options.onProperty?.(parent, p, v);

--- a/packages/sss/src/parsers/parseSelector.ts
+++ b/packages/sss/src/parsers/parseSelector.ts
@@ -34,7 +34,7 @@ export default function parseSelector<T extends object>(
     }
 
     const block = new Block(name);
-    block.selector = parent.selector + name;
+    block.selector = name;
 
     const args: Parameters<NestedListener<T>> = [
       parent,

--- a/packages/sss/src/parsers/parseSelector.ts
+++ b/packages/sss/src/parsers/parseSelector.ts
@@ -33,8 +33,15 @@ export default function parseSelector<T extends object>(
       name = name.slice(1);
     }
 
-    const block = parseLocalBlock(parent.addNested(new Block(name)), object, options);
-    const args: Parameters<NestedListener<T>> = [parent, name, block, { specificity }];
+    const block = new Block(name);
+    block.selector = parent.selector + name;
+
+    const args: Parameters<NestedListener<T>> = [
+      parent,
+      name,
+      parseLocalBlock(parent.addNested(block), object, options),
+      { specificity },
+    ];
 
     if (name[0] === ':') {
       options.onPseudo?.(...args);

--- a/packages/sss/src/parsers/parseSelector.ts
+++ b/packages/sss/src/parsers/parseSelector.ts
@@ -39,7 +39,7 @@ export default function parseSelector<T extends object>(
     const args: Parameters<NestedListener<T>> = [
       parent,
       name,
-      parseLocalBlock(parent.addNested(block), object, options),
+      parseLocalBlock(parent.nest(block), object, options),
       { specificity },
     ];
 

--- a/packages/sss/src/parsers/parseVariables.ts
+++ b/packages/sss/src/parsers/parseVariables.ts
@@ -23,7 +23,8 @@ export default function parseVariables<T extends object>(
     }
 
     if (parent) {
-      parent.addVariable(name, value);
+      parent.variables[name] = value;
+
       options.onVariable?.(parent, name, value);
     } else {
       object[name] = value;

--- a/packages/sss/src/parsers/parseVariants.ts
+++ b/packages/sss/src/parsers/parseVariants.ts
@@ -16,7 +16,11 @@ export default function parseVariants<T extends object>(
   objectLoop(variants, (variant, parentType) => {
     objectLoop(variant, (object, childType) => {
       const type = `${parentType}_${childType}`;
-      const block = parseLocalBlock(parent.addVariant(type, new Block()), object, options);
+
+      const variantBlock = new Block();
+      parent.variants[type] = variantBlock;
+
+      const block = parseLocalBlock(variantBlock, object, options);
 
       options.onVariant?.(parent, type, block, { specificity: 0 });
     });

--- a/packages/sss/tests/Block.test.ts
+++ b/packages/sss/tests/Block.test.ts
@@ -32,7 +32,8 @@ describe('Block', () => {
 
   describe('addNested()', () => {
     it('adds a nested object', () => {
-      const obj = createBlock(':hover').addProperty('color', 'red');
+      const obj = createBlock(':hover');
+      obj.properties.color = 'red';
 
       instance.addNested(obj);
 
@@ -40,63 +41,35 @@ describe('Block', () => {
     });
 
     it('merges nested objects if selectors are the same', () => {
-      const obj1 = createBlock(':hover')
-        .addProperty('color', 'red')
-        .addProperty('display', 'block');
-      const obj2 = createBlock(':hover')
-        .addProperty('color', 'blue')
-        .addProperty('background', 'white');
+      const obj1 = createBlock(':hover');
+      obj1.properties.color = 'red';
+      obj1.properties.display = 'block';
+
+      const obj2 = createBlock(':hover');
+      obj2.properties.color = 'blue';
+      obj2.properties.background = 'white';
 
       instance.addNested(obj1);
       instance.addNested(obj2);
 
-      const obj3 = createBlock(':hover')
-        .addProperty('display', 'block')
-        .addProperty('color', 'blue')
-        .addProperty('background', 'white');
+      const obj3 = createBlock(':hover');
+      obj3.properties.color = 'blue';
+      obj3.properties.display = 'block';
+      obj3.properties.background = 'white';
       obj3.parent = instance;
 
       expect(instance.nested[':hover']).toEqual(obj3);
     });
   });
 
-  describe('addProperty()', () => {
-    it('sets a property', () => {
-      instance.addProperty('color', 'red');
-
-      expect(instance.properties.color).toBe('red');
-    });
-
-    it('overwrites a property of the same name', () => {
-      instance.addProperty('color', 'red');
-      instance.addProperty('color', 'blue');
-
-      expect(instance.properties.color).toBe('blue');
-    });
-  });
-
-  describe('addVariable()', () => {
-    it('sets a variable', () => {
-      instance.addVariable('--color', 'red');
-
-      expect(instance.variables['--color']).toBe('red');
-    });
-
-    it('overwrites a variable of the same name', () => {
-      instance.addVariable('--color', 'red');
-      instance.addVariable('--color', 'blue');
-
-      expect(instance.variables['--color']).toBe('blue');
-    });
-  });
-
   describe('merge()', () => {
     it('inherits properties from rule', () => {
-      instance.addProperty('color', 'red').addProperty('display', 'block');
+      instance.properties.color = 'red';
+      instance.properties.display = 'block';
 
-      const rule = createBlock('nested')
-        .addProperty('color', 'blue')
-        .addProperty('background', 'white');
+      const rule = createBlock('nested');
+      rule.properties.color = 'blue';
+      rule.properties.background = 'white';
 
       instance.merge(rule);
 
@@ -109,19 +82,27 @@ describe('Block', () => {
 
     it('inherits nested from rule', () => {
       // Base
-      const hover = createBlock(':hover').addProperty('color', 'black');
-      const active = createBlock(':active').addProperty('color', 'blue');
-      const media = createBlock('@media (max-width: 100px)').addProperty('display', 'block');
-      const mediaHover = createBlock(':hover').addProperty('display', 'inline');
+      const hover = createBlock(':hover');
+      hover.properties.color = 'black';
+
+      const active = createBlock(':active');
+      active.properties.color = 'blue';
+
+      const media = createBlock('@media (max-width: 100px)');
+      media.properties.display = 'block';
+
+      const mediaHover = createBlock(':hover');
+      mediaHover.properties.display = 'inline';
 
       // New
-      const hover2 = createBlock(':hover')
-        .addProperty('color', 'black')
-        .addProperty('position', 'relative');
+      const hover2 = createBlock(':hover');
+      hover2.properties.color = 'black';
+      hover2.properties.position = 'relative';
+
       const media2 = createBlock('@media (max-width: 100px)');
-      const mediaHover2 = createBlock(':hover')
-        .addProperty('display', 'inline-flex')
-        .addProperty('background', 'transparent');
+      const mediaHover2 = createBlock(':hover');
+      mediaHover2.properties.display = 'inline-flex';
+      mediaHover2.properties.background = 'transparent';
 
       instance.addNested(hover);
       instance.addNested(active);
@@ -158,10 +139,9 @@ describe('Block', () => {
 
   describe('toObject()', () => {
     it('returns a plain object', () => {
-      instance
-        .addProperty('color', 'red')
-        .addProperty('display', 'block')
-        .addVariable('--font-size', '14px');
+      instance.properties.color = 'red';
+      instance.properties.display = 'block';
+      instance.variables['--font-size'] = '14px';
 
       expect(instance.toObject()).toEqual({
         '--font-size': '14px',

--- a/packages/sss/tests/Block.test.ts
+++ b/packages/sss/tests/Block.test.ts
@@ -20,8 +20,8 @@ describe('Block', () => {
       const child = createBlock('');
       const grandchild = createBlock(':hover');
 
-      instance.addNested(child);
-      child.addNested(grandchild);
+      instance.nest(child);
+      child.nest(grandchild);
 
       grandchild.addClassName('foo');
 
@@ -30,12 +30,12 @@ describe('Block', () => {
     });
   });
 
-  describe('addNested()', () => {
+  describe('nest()', () => {
     it('adds a nested object', () => {
       const obj = createBlock(':hover');
       obj.properties.color = 'red';
 
-      instance.addNested(obj);
+      instance.nest(obj);
 
       expect(instance.nested[':hover']).toEqual(obj);
     });
@@ -49,8 +49,8 @@ describe('Block', () => {
       obj2.properties.color = 'blue';
       obj2.properties.background = 'white';
 
-      instance.addNested(obj1);
-      instance.addNested(obj2);
+      instance.nest(obj1);
+      instance.nest(obj2);
 
       const obj3 = createBlock(':hover');
       obj3.properties.color = 'blue';
@@ -104,16 +104,16 @@ describe('Block', () => {
       mediaHover2.properties.display = 'inline-flex';
       mediaHover2.properties.background = 'transparent';
 
-      instance.addNested(hover);
-      instance.addNested(active);
-      instance.addNested(media);
+      instance.nest(hover);
+      instance.nest(active);
+      instance.nest(media);
 
-      media.addNested(mediaHover);
-      media2.addNested(mediaHover2);
+      media.nest(mediaHover);
+      media2.nest(mediaHover2);
 
       const next = createBlock('new');
-      next.addNested(hover2);
-      next.addNested(media2);
+      next.nest(hover2);
+      next.nest(media2);
 
       instance.merge(next);
 

--- a/packages/sss/tests/Block.test.ts
+++ b/packages/sss/tests/Block.test.ts
@@ -90,31 +90,6 @@ describe('Block', () => {
     });
   });
 
-  describe('getSelectors()', () => {
-    it('returns current selector if defined', () => {
-      expect(instance.getSelectors()).toEqual(['test']);
-    });
-
-    it('returns an empty array if not defined', () => {
-      instance = createBlock('');
-
-      expect(instance.getSelectors()).toEqual([]);
-    });
-
-    it('returns a list of all ancestry selectors, skipping over empty ones', () => {
-      const child = createBlock('');
-      const grandchild = createBlock(':hover');
-
-      instance.addNested(child);
-      child.addNested(grandchild);
-
-      grandchild.addClassName('foo');
-
-      expect(instance.getSelectors()).toEqual(['test']);
-      expect(grandchild.getSelectors()).toEqual(['test', ':hover']);
-    });
-  });
-
   describe('merge()', () => {
     it('inherits properties from rule', () => {
       instance.addProperty('color', 'red').addProperty('display', 'block');

--- a/packages/sss/tests/GlobalParser.test.ts
+++ b/packages/sss/tests/GlobalParser.test.ts
@@ -131,20 +131,16 @@ describe('GlobalParser', () => {
       );
 
       expect(spy).toHaveBeenCalledWith(
-        createBlock(
-          '@root',
-          {
-            height: '100%',
-            margin: 0,
-            fontSize: 16,
-            lineHeight: 1.5,
-            backgroundColor: 'white',
-            '@media (prefers-color-scheme: dark)': {
-              backgroundColor: 'black',
-            },
+        createBlock('@root', {
+          height: '100%',
+          margin: 0,
+          fontSize: 16,
+          lineHeight: 1.5,
+          backgroundColor: 'white',
+          '@media (prefers-color-scheme: dark)': {
+            backgroundColor: 'black',
           },
-          { media: '(prefers-color-scheme: dark)' },
-        ),
+        }),
       );
     });
   });

--- a/packages/sss/tests/GlobalParser.test.ts
+++ b/packages/sss/tests/GlobalParser.test.ts
@@ -125,7 +125,7 @@ describe('GlobalParser', () => {
         {
           onRoot: spy,
           onMedia(block, query, value) {
-            block.addNested(value);
+            block.nest(value);
           },
         },
       );

--- a/packages/sss/tests/GlobalParser.test.ts
+++ b/packages/sss/tests/GlobalParser.test.ts
@@ -131,16 +131,20 @@ describe('GlobalParser', () => {
       );
 
       expect(spy).toHaveBeenCalledWith(
-        createBlock('@root', {
-          height: '100%',
-          margin: 0,
-          fontSize: 16,
-          lineHeight: 1.5,
-          backgroundColor: 'white',
-          '@media (prefers-color-scheme: dark)': {
-            backgroundColor: 'black',
+        createBlock(
+          '@root',
+          {
+            height: '100%',
+            margin: 0,
+            fontSize: 16,
+            lineHeight: 1.5,
+            backgroundColor: 'white',
+            '@media (prefers-color-scheme: dark)': {
+              backgroundColor: 'black',
+            },
           },
-        }),
+          { media: '(prefers-color-scheme: dark)' },
+        ),
       );
     });
   });

--- a/packages/sss/tests/LocalParser.test.ts
+++ b/packages/sss/tests/LocalParser.test.ts
@@ -332,7 +332,7 @@ describe('LocalParser', () => {
         { media: '(min-width: 300px) and (max-width: 1000px)' },
       );
 
-      parent.addNested(child);
+      parent.nest(child);
       child.parent = parent;
 
       expect(spy).toHaveBeenCalledWith(expect.any(Block), '(min-width: 300px)', parent);

--- a/packages/sss/tests/LocalParser.test.ts
+++ b/packages/sss/tests/LocalParser.test.ts
@@ -323,24 +323,20 @@ describe('LocalParser', () => {
 
       expect(spy).toHaveBeenCalledTimes(2);
 
-      expect(spy).toHaveBeenCalledWith(
-        expect.any(Block),
-        '(min-width: 300px)',
-        createExpectedBlock('@media (min-width: 300px)', {
-          color: 'blue',
-          '@media (max-width: 1000px)': {
-            color: 'green',
-          },
-        }),
+      const parent = createExpectedBlock('@media (min-width: 300px)', {
+        color: 'blue',
+      });
+      const child = createExpectedBlock(
+        '@media (max-width: 1000px)',
+        { color: 'green' },
+        { media: '(min-width: 300px) and (max-width: 1000px)' },
       );
 
-      expect(spy).toHaveBeenCalledWith(
-        expect.any(Block),
-        '(max-width: 1000px)',
-        createExpectedBlock('@media (max-width: 1000px)', {
-          color: 'green',
-        }),
-      );
+      parent.addNested(child);
+      child.parent = parent;
+
+      expect(spy).toHaveBeenCalledWith(expect.any(Block), '(min-width: 300px)', parent);
+      expect(spy).toHaveBeenCalledWith(expect.any(Block), '(max-width: 1000px)', child);
     });
   });
 

--- a/packages/sss/tests/LocalParser.test.ts
+++ b/packages/sss/tests/LocalParser.test.ts
@@ -67,6 +67,116 @@ describe('LocalParser', () => {
     expect(spy).toHaveBeenCalledWith('selector', createBlock('', SYNTAX_LOCAL_BLOCK));
   });
 
+  it('applies nested conditionals and selectors correctly', () => {
+    parse(
+      {
+        element: {
+          '@media': {
+            '(max-width: 1000px)': {
+              ':hover': {},
+              '@supports': {
+                '(display: flex)': {
+                  '[disabled]': {},
+                  '@media': {
+                    '(min-width: 500px)': {
+                      '@media': {
+                        '(prefers-contrast: low)': {
+                          '@supports': {
+                            '(color: red)': {
+                              color: 'red',
+                            },
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+          '@selectors': {
+            ':not([disabled])': {
+              ':focus': {},
+            },
+          },
+        },
+      },
+      { onRule: spy },
+    );
+
+    const block = createExpectedBlock('');
+    block.parent = undefined;
+
+    const media1000 = createExpectedBlock(
+      '@media (max-width: 1000px)',
+      {},
+      { parent: block, media: '(max-width: 1000px)' },
+    );
+
+    createExpectedBlock(
+      ':hover',
+      {},
+      { parent: media1000, media: '(max-width: 1000px)', selector: ':hover' },
+    );
+
+    const supportsFlex = createExpectedBlock(
+      '@supports (display: flex)',
+      {},
+      { parent: media1000, media: '(max-width: 1000px)', supports: '(display: flex)' },
+    );
+
+    createExpectedBlock(
+      '[disabled]',
+      {},
+      {
+        parent: supportsFlex,
+        media: '(max-width: 1000px)',
+        selector: '[disabled]',
+        supports: '(display: flex)',
+      },
+    );
+
+    const media500 = createExpectedBlock(
+      '@media (min-width: 500px)',
+      {},
+      {
+        parent: supportsFlex,
+        media: '(max-width: 1000px) and (min-width: 500px)',
+        supports: '(display: flex)',
+      },
+    );
+
+    const mediaLow = createExpectedBlock(
+      '@media (prefers-contrast: low)',
+      {},
+      {
+        parent: media500,
+        media: '(max-width: 1000px) and (min-width: 500px) and (prefers-contrast: low)',
+        supports: '(display: flex)',
+      },
+    );
+
+    createExpectedBlock(
+      '@supports (color: red)',
+      { color: 'red' },
+      {
+        parent: mediaLow,
+        media: '(max-width: 1000px) and (min-width: 500px) and (prefers-contrast: low)',
+        supports: '(display: flex) and (color: red)',
+      },
+    );
+
+    const notDisabled = createExpectedBlock(
+      ':not([disabled])',
+      {},
+      { parent: block, selector: ':not([disabled])' },
+    );
+
+    createExpectedBlock(':focus', {}, { parent: notDisabled, selector: ':not([disabled]):focus' });
+
+    expect(spy).toHaveBeenCalledWith('element', block);
+  });
+
   describe('class names', () => {
     it('emits for each class name', () => {
       parse(
@@ -326,14 +436,12 @@ describe('LocalParser', () => {
       const parent = createExpectedBlock('@media (min-width: 300px)', {
         color: 'blue',
       });
+
       const child = createExpectedBlock(
         '@media (max-width: 1000px)',
         { color: 'green' },
-        { media: '(min-width: 300px) and (max-width: 1000px)' },
+        { parent, media: '(min-width: 300px) and (max-width: 1000px)' },
       );
-
-      parent.nest(child);
-      child.parent = parent;
 
       expect(spy).toHaveBeenCalledWith(expect.any(Block), '(min-width: 300px)', parent);
       expect(spy).toHaveBeenCalledWith(expect.any(Block), '(max-width: 1000px)', child);

--- a/packages/sss/tests/helpers.ts
+++ b/packages/sss/tests/helpers.ts
@@ -1,9 +1,19 @@
+/* eslint-disable no-magic-numbers */
+
 import { objectLoop, isObject } from '@aesthetic/utils';
 import Block from '../src/Block';
 import { Properties } from '../src/types';
 
-export function createBlock(selector: string, properties?: object): Block<Properties> {
-  const block = new Block(selector);
+export function createBlock(id: string, properties?: object): Block<Properties> {
+  const block = new Block(id);
+
+  if (id.startsWith('@media')) {
+    block.media = id.slice(6).trim();
+  } else if (id.startsWith('@supports')) {
+    block.supports = id.slice(9).trim();
+  } else if (id.match(/^[^a-z0-9@]/iu)) {
+    block.selector = id;
+  }
 
   if (properties === undefined) {
     return block;
@@ -20,8 +30,24 @@ export function createBlock(selector: string, properties?: object): Block<Proper
   return block;
 }
 
-export function createExpectedBlock(selector: string, properties?: object): Block<Properties> {
-  const block = createBlock(selector, properties);
+export function createExpectedBlock(
+  id: string,
+  properties?: object,
+  { media, selector, supports }: Partial<Pick<Block, 'media' | 'selector' | 'supports'>> = {},
+): Block<Properties> {
+  const block = createBlock(id, properties);
+
+  if (media) {
+    block.media = media;
+  }
+
+  if (selector) {
+    block.selector = selector;
+  }
+
+  if (supports) {
+    block.supports = supports;
+  }
 
   // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
   block.parent = expect.any(Block);

--- a/packages/sss/tests/helpers.ts
+++ b/packages/sss/tests/helpers.ts
@@ -23,7 +23,7 @@ export function createBlock(id: string, properties?: object): Block<Properties> 
     if (isObject(value)) {
       block.addNested(createBlock(key, value));
     } else {
-      block.addProperty(key, value);
+      block.properties[key] = value;
     }
   });
 

--- a/packages/sss/tests/helpers.ts
+++ b/packages/sss/tests/helpers.ts
@@ -11,7 +11,7 @@ export function createBlock(id: string, properties?: object): Block<Properties> 
     block.media = id.slice(6).trim();
   } else if (id.startsWith('@supports')) {
     block.supports = id.slice(9).trim();
-  } else if (id.match(/^[^a-z0-9@]/iu)) {
+  } else if (id.match(/^(:|\[|>|\*|~|\+)/iu)) {
     block.selector = id;
   }
 
@@ -33,9 +33,18 @@ export function createBlock(id: string, properties?: object): Block<Properties> 
 export function createExpectedBlock(
   id: string,
   properties?: object,
-  { media, selector, supports }: Partial<Pick<Block, 'media' | 'selector' | 'supports'>> = {},
+  {
+    media,
+    parent,
+    selector,
+    supports,
+  }: Partial<Pick<Block, 'media' | 'parent' | 'selector' | 'supports'>> = {},
 ): Block<Properties> {
   const block = createBlock(id, properties);
+
+  if (parent) {
+    parent.nest(block);
+  }
 
   if (media) {
     block.media = media;

--- a/packages/sss/tests/helpers.ts
+++ b/packages/sss/tests/helpers.ts
@@ -21,7 +21,7 @@ export function createBlock(id: string, properties?: object): Block<Properties> 
 
   objectLoop(properties, (value, key) => {
     if (isObject(value)) {
-      block.addNested(createBlock(key, value));
+      block.nest(createBlock(key, value));
     } else {
       block.properties[key] = value;
     }

--- a/packages/utils/src/joinQueries.ts
+++ b/packages/utils/src/joinQueries.ts
@@ -1,7 +1,19 @@
 export default function joinQueries(prev: string | undefined, next: string): string {
-  if (prev) {
+  if (prev && next) {
+    if (prev.includes(next)) {
+      return prev;
+    }
+
     return `${prev} and ${next}`;
   }
 
-  return next;
+  if (next) {
+    return next;
+  }
+
+  if (prev) {
+    return prev;
+  }
+
+  return '';
 }

--- a/packages/utils/tests/joinQueries.test.ts
+++ b/packages/utils/tests/joinQueries.test.ts
@@ -1,0 +1,31 @@
+import joinQueries from '../src/joinQueries';
+
+describe('joinQueries()', () => {
+  it('returns next if prev is undefined', () => {
+    expect(joinQueries(undefined, '(max-width: 100px)')).toBe('(max-width: 100px)');
+  });
+
+  it('returns next if prev is empty', () => {
+    expect(joinQueries('', '(max-width: 100px)')).toBe('(max-width: 100px)');
+  });
+
+  it('returns prev if next is empty', () => {
+    expect(joinQueries('(max-width: 100px)', '')).toBe('(max-width: 100px)');
+  });
+
+  it('returns empty string if prev and next are empty', () => {
+    expect(joinQueries('', '')).toBe('');
+  });
+
+  it('joins next and prev if defined', () => {
+    expect(joinQueries('(min-width: 0px)', '(max-width: 100px)')).toBe(
+      '(min-width: 0px) and (max-width: 100px)',
+    );
+  });
+
+  it('doesnt join next if value already exists in prev', () => {
+    expect(joinQueries('(min-width: 0px) and (max-width: 100px)', '(max-width: 100px)')).toBe(
+      '(min-width: 0px) and (max-width: 100px)',
+    );
+  });
+});


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/aesthetic-suite/framework/blob/main/CONTRIBUTING.md
-->

<!-- If fixing an issue, uncomment the following and include a link/issue number. -->

<!-- Fixes issue # -->

## Summary

This builds upon https://github.com/aesthetic-suite/framework/pull/138 to define media/selector/supports on the block automatically from SSS so we no longer need to figure it out in core.

Also cleaning up SSS a bit and removing unnecessary code.

## Screenshots

<!-- If applicable, screenshots or videos of the change working correctly. -->

## Checklist

- [x] Build passes with `yarn test`.
- [x] Code is formatted with `yarn format`.
- [x] Tests have been added for my changes.
- [x] Code coverage for my change is 100%.
- [ ] Documentation has been updated for my changes.
