### PR TITLE
breaking: Refactor variants to support compound variants.

### DIFF
--- a/configs/jest.js
+++ b/configs/jest.js
@@ -1,0 +1,4 @@
+module.exports = {
+  coveragePathIgnorePatterns: ['system/src/mixins'],
+  testEnvironment: 'jsdom',
+};

--- a/package.json
+++ b/package.json
@@ -59,9 +59,6 @@
     "settings": {
       "decorators": true,
       "react": true
-    },
-    "jest": {
-      "testEnvironment": "jsdom"
     }
   },
   "workspaces": [

--- a/packages/core/src/Aesthetic.ts
+++ b/packages/core/src/Aesthetic.ts
@@ -176,7 +176,7 @@ export default class Aesthetic<Result = ClassName, Block extends object = LocalB
 
   /**
    * Generate a class name using the selectors of a style sheet.
-   * If an object is provided, it will be used to check for variants.
+   * If a set is provided, it will be used to check for variants.
    */
   generateClassName = <T extends string>(
     keys: T[],
@@ -184,6 +184,7 @@ export default class Aesthetic<Result = ClassName, Block extends object = LocalB
     classNames: RenderResultSheet<ClassName>,
   ): ClassName => {
     let className = '';
+    let variantClassName = '';
 
     arrayLoop(keys, (key) => {
       const hash = classNames[key];
@@ -200,14 +201,14 @@ export default class Aesthetic<Result = ClassName, Block extends object = LocalB
       if (hash.variants) {
         arrayLoop(hash.variants, ({ match, result }) => {
           if (match.every((type) => variants.has(type))) {
-            className += ' ';
-            className += result;
+            variantClassName += ' ';
+            variantClassName += result;
           }
         });
       }
     });
 
-    return className.trim();
+    return (className + variantClassName).trim();
   };
 
   /**

--- a/packages/core/src/Aesthetic.ts
+++ b/packages/core/src/Aesthetic.ts
@@ -180,7 +180,7 @@ export default class Aesthetic<Result = ClassName, Block extends object = LocalB
    */
   generateClassName = <T extends string>(
     keys: T[],
-    variants: string[],
+    variants: Set<string>,
     classNames: RenderResultSheet<ClassName>,
   ): ClassName => {
     let className = '';
@@ -198,10 +198,10 @@ export default class Aesthetic<Result = ClassName, Block extends object = LocalB
       }
 
       if (hash.variants) {
-        arrayLoop(variants, (variant) => {
-          if (hash.variants?.[variant]) {
+        arrayLoop(hash.variants, ({ match, result }) => {
+          if (match.every((type) => variants.has(type))) {
             className += ' ';
-            className += hash.variants[variant];
+            className += result;
           }
         });
       }

--- a/packages/core/src/StyleSheet.ts
+++ b/packages/core/src/StyleSheet.ts
@@ -19,61 +19,61 @@ function createCacheKey(params: Required<SheetParams>, type: string): string | n
 export default class StyleSheet<Result, Factory extends BaseSheetFactory> {
   readonly type: 'global' | 'local';
 
-  protected contrastVariants: { [K in ContrastLevel]?: Factory } = {};
+  protected contrastOverrides: { [K in ContrastLevel]?: Factory } = {};
 
   protected factory: Factory;
 
   protected renderCache: Record<string, RenderResultSheet<Result>> = {};
 
-  protected schemeVariants: { [K in ColorScheme]?: Factory } = {};
+  protected schemeOverrides: { [K in ColorScheme]?: Factory } = {};
 
-  protected themeVariants: Record<string, Factory> = {};
+  protected themeOverrides: Record<string, Factory> = {};
 
   constructor(type: 'global' | 'local', factory: Factory) {
     this.type = type;
     this.factory = this.validateFactory(factory);
   }
 
-  addColorSchemeVariant(scheme: ColorScheme, factory: Factory): this {
+  addColorSchemeOverride(scheme: ColorScheme, factory: Factory): this {
     if (__DEV__) {
       if (this.type !== 'local') {
-        throw new Error('Color scheme variants are only supported by local style sheets.');
+        throw new Error('Color scheme overrides are only supported by local style sheets.');
       }
 
       if (scheme !== 'light' && scheme !== 'dark') {
-        throw new Error('Color scheme variant must be one of "light" or "dark".');
+        throw new Error('Color scheme override must be one of "light" or "dark".');
       }
     }
 
-    this.schemeVariants[scheme] = this.validateFactory(factory);
+    this.schemeOverrides[scheme] = this.validateFactory(factory);
 
     return this;
   }
 
-  addContrastVariant(contrast: ContrastLevel, factory: Factory): this {
+  addContrastOverride(contrast: ContrastLevel, factory: Factory): this {
     if (__DEV__) {
       if (this.type !== 'local') {
-        throw new Error('Contrast level variants are only supported by local style sheets.');
+        throw new Error('Contrast level overrides are only supported by local style sheets.');
       }
 
       if (contrast !== 'normal' && contrast !== 'high' && contrast !== 'low') {
-        throw new Error('Contrast level variant must be one of "high", "low", or "normal".');
+        throw new Error('Contrast level override must be one of "high", "low", or "normal".');
       }
     }
 
-    this.contrastVariants[contrast] = this.validateFactory(factory);
+    this.contrastOverrides[contrast] = this.validateFactory(factory);
 
     return this;
   }
 
-  addThemeVariant(theme: string, factory: Factory): this {
+  addThemeOverride(theme: string, factory: Factory): this {
     if (__DEV__) {
       if (this.type !== 'local') {
-        throw new Error('Theme variants are only supported by local style sheets.');
+        throw new Error('Theme overrides are only supported by local style sheets.');
       }
     }
 
-    this.themeVariants[theme] = this.validateFactory(factory);
+    this.themeOverrides[theme] = this.validateFactory(factory);
 
     return this;
   }
@@ -85,16 +85,16 @@ export default class StyleSheet<Result, Factory extends BaseSheetFactory> {
 
     const factories = [this.factory];
 
-    if (params.scheme && this.schemeVariants[params.scheme]) {
-      factories.push(this.schemeVariants[params.scheme]!);
+    if (params.scheme && this.schemeOverrides[params.scheme]) {
+      factories.push(this.schemeOverrides[params.scheme]!);
     }
 
-    if (params.contrast && this.contrastVariants[params.contrast]) {
-      factories.push(this.contrastVariants[params.contrast]!);
+    if (params.contrast && this.contrastOverrides[params.contrast]) {
+      factories.push(this.contrastOverrides[params.contrast]!);
     }
 
-    if (params.theme && this.themeVariants[params.theme]) {
-      factories.push(this.themeVariants[params.theme]!);
+    if (params.theme && this.themeOverrides[params.theme]) {
+      factories.push(this.themeOverrides[params.theme]!);
     }
 
     if (factories.length === 1) {

--- a/packages/core/src/StyleSheet.ts
+++ b/packages/core/src/StyleSheet.ts
@@ -208,7 +208,7 @@ export default class StyleSheet<Result, Factory extends BaseSheetFactory> {
         }
 
         meta.variants[type] = block.result as Result;
-        meta.variantTypes.add(type.split('_')[0]);
+        meta.variantTypes.add(type.split(':')[0]);
       },
     });
 

--- a/packages/core/src/StyleSheet.ts
+++ b/packages/core/src/StyleSheet.ts
@@ -1,7 +1,7 @@
 import { parse } from '@aesthetic/sss';
 import { Theme } from '@aesthetic/system';
 import { ColorScheme, ContrastLevel, Engine, Property, RenderOptions } from '@aesthetic/types';
-import { deepMerge, objectLoop } from '@aesthetic/utils';
+import { deepMerge, objectLoop, toArray } from '@aesthetic/utils';
 import { BaseSheetFactory, RenderResultSheet, SheetParams, SheetParamsExtended } from './types';
 
 function createCacheKey(params: Required<SheetParams>, type: string): string | null {
@@ -192,23 +192,30 @@ export default class StyleSheet<Result, Factory extends BaseSheetFactory> {
           block.addResult(engine.renderVariable(name, value));
         }
       },
-      onVariant: (parent, type, block) => {
+      onVariant: (parent, variant, block) => {
         if (!engine.atomic) {
           block.addResult(engine.renderRule(block.toObject(), renderOptions));
         }
 
         const meta = createResultMetadata(parent.id);
+        const list = toArray(variant);
 
         if (!meta.variants) {
-          meta.variants = {};
+          meta.variants = [];
         }
 
         if (!meta.variantTypes) {
           meta.variantTypes = new Set();
         }
 
-        meta.variants[type] = block.result as Result;
-        meta.variantTypes.add(type.split(':')[0]);
+        meta.variants.push({
+          match: list,
+          result: block.result as Result,
+        });
+
+        list.forEach((type) => {
+          meta.variantTypes!.add(type.split(':')[0]);
+        });
       },
     });
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -28,9 +28,14 @@ export type ElementStyles = LocalBlock;
 export type ComponentStyles = LocalStyleSheet<ElementStyles>;
 export type ThemeStyles = GlobalStyleSheet<ElementStyles>;
 
+export interface RenderResultVariant<T> {
+  match: string[];
+  result: T;
+}
+
 export interface RenderResult<T> {
   result?: T;
-  variants?: Record<string, T>;
+  variants?: RenderResultVariant<T>[];
   variantTypes?: Set<string>;
 }
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -67,7 +67,7 @@ export type GlobalSheetFactory<Shape = unknown, Block extends object = LocalBloc
 
 export type GlobalSheet<Shape, Block extends object, Result> = Omit<
   StyleSheet<Result, GlobalSheetFactory<Shape, Block>>,
-  'addColorSchemeVariant' | 'addContrastVariant' | 'addThemeVariant'
+  'addColorSchemeOverride' | 'addContrastOverride' | 'addThemeOverride'
 >;
 
 export type LocalSheetFactory<Shape = unknown, Block extends object = LocalBlock> = (

--- a/packages/core/tests/Aesthetic.test.ts
+++ b/packages/core/tests/Aesthetic.test.ts
@@ -3,6 +3,7 @@ import vendorPrefixer from '@aesthetic/addon-vendor';
 import { createClientEngine } from '@aesthetic/style';
 import { createTestStyleEngine, purgeStyles } from '@aesthetic/style/test';
 import { ClassName } from '@aesthetic/types';
+import { toArray } from '@aesthetic/utils';
 import { Aesthetic, RenderResultSheet, StyleSheet } from '../src';
 import {
   darkTheme,
@@ -11,6 +12,10 @@ import {
   setupAesthetic,
   teardownAesthetic,
 } from '../src/test';
+
+function createVariant(type: string[] | string, result: string) {
+  return { match: toArray(type), result };
+}
 
 describe('Aesthetic', () => {
   let aesthetic: Aesthetic;
@@ -266,36 +271,42 @@ describe('Aesthetic', () => {
 
   describe('generateClassName()', () => {
     const classes: RenderResultSheet<ClassName> = {
-      a: { result: 'a', variants: { 'size:df': 'a_size_df' } },
+      a: { result: 'a', variants: [createVariant('size:df', 'a_size_df')] },
       b: { result: 'b' },
-      c: { result: 'c', variants: { 'size:md': 'c_size_md', 'type:red': 'c_size_red' } },
-      d: { variants: { 'size:df': 'd_size_df' } },
+      c: {
+        result: 'c',
+        variants: [createVariant('size:md', 'c_size_md'), createVariant('type:red', 'c_size_red')],
+      },
+      d: { variants: [createVariant('size:df', 'd_size_df')] },
       e: { result: 'e' },
-      f: { result: 'f', variants: { 'size:df': 'f_size_df', 'size:md': 'f_size_md' } },
-      g: { result: 'g', variants: { 'type:red': 'c_size_red' } },
+      f: {
+        result: 'f',
+        variants: [createVariant('size:df', 'f_size_df'), createVariant('size:md', 'f_size_md')],
+      },
+      g: { result: 'g', variants: [createVariant('type:red', 'c_size_red')] },
     };
 
     it('returns class names', () => {
-      expect(aesthetic.generateClassName(['a', 'e'], [], classes)).toBe('a e');
+      expect(aesthetic.generateClassName(['a', 'e'], new Set(), classes)).toBe('a e');
     });
 
     it('returns class names and their variants', () => {
-      expect(aesthetic.generateClassName(['a'], ['size:df'], classes)).toBe('a a_size_df');
-      expect(aesthetic.generateClassName(['a', 'f'], ['size:df'], classes)).toBe(
+      expect(aesthetic.generateClassName(['a'], new Set(['size:df']), classes)).toBe('a a_size_df');
+      expect(aesthetic.generateClassName(['a', 'f'], new Set(['size:df']), classes)).toBe(
         'a a_size_df f f_size_df',
       );
     });
 
     it('returns nothing for an invalid selector', () => {
-      expect(aesthetic.generateClassName(['z'], [], classes)).toBe('');
+      expect(aesthetic.generateClassName(['z'], new Set(), classes)).toBe('');
     });
 
     it('returns nothing for a valid selector but no class name', () => {
-      expect(aesthetic.generateClassName(['d'], [], classes)).toBe('');
+      expect(aesthetic.generateClassName(['d'], new Set(), classes)).toBe('');
     });
 
     it('returns variants even if theres no base class name', () => {
-      expect(aesthetic.generateClassName(['d'], ['size:df'], classes)).toBe('d_size_df');
+      expect(aesthetic.generateClassName(['d'], new Set(['size:df']), classes)).toBe('d_size_df');
     });
   });
 
@@ -501,7 +512,11 @@ describe('Aesthetic', () => {
 
       expect(aesthetic.renderComponentStyles(sheet)).toEqual({
         foo: { result: 'a' },
-        bar: { result: 'b', variants: { 'type:red': 'c' }, variantTypes: new Set(['type']) },
+        bar: {
+          result: 'b',
+          variants: [createVariant('type:red', 'c')],
+          variantTypes: new Set(['type']),
+        },
         baz: { result: 'd' },
       });
       expect(spy).toHaveBeenCalledWith(aesthetic.getEngine(), lightTheme, {

--- a/packages/core/tests/Aesthetic.test.ts
+++ b/packages/core/tests/Aesthetic.test.ts
@@ -266,13 +266,13 @@ describe('Aesthetic', () => {
 
   describe('generateClassName()', () => {
     const classes: RenderResultSheet<ClassName> = {
-      a: { result: 'a', variants: { size_df: 'a_size_df' } },
+      a: { result: 'a', variants: { 'size:df': 'a_size_df' } },
       b: { result: 'b' },
-      c: { result: 'c', variants: { size_md: 'c_size_md', type_red: 'c_size_red' } },
-      d: { variants: { size_df: 'd_size_df' } },
+      c: { result: 'c', variants: { 'size:md': 'c_size_md', 'type:red': 'c_size_red' } },
+      d: { variants: { 'size:df': 'd_size_df' } },
       e: { result: 'e' },
-      f: { result: 'f', variants: { size_df: 'f_size_df', size_md: 'f_size_md' } },
-      g: { result: 'g', variants: { type_red: 'c_size_red' } },
+      f: { result: 'f', variants: { 'size:df': 'f_size_df', 'size:md': 'f_size_md' } },
+      g: { result: 'g', variants: { 'type:red': 'c_size_red' } },
     };
 
     it('returns class names', () => {
@@ -280,8 +280,8 @@ describe('Aesthetic', () => {
     });
 
     it('returns class names and their variants', () => {
-      expect(aesthetic.generateClassName(['a'], ['size_df'], classes)).toBe('a a_size_df');
-      expect(aesthetic.generateClassName(['a', 'f'], ['size_df'], classes)).toBe(
+      expect(aesthetic.generateClassName(['a'], ['size:df'], classes)).toBe('a a_size_df');
+      expect(aesthetic.generateClassName(['a', 'f'], ['size:df'], classes)).toBe(
         'a a_size_df f f_size_df',
       );
     });
@@ -295,7 +295,7 @@ describe('Aesthetic', () => {
     });
 
     it('returns variants even if theres no base class name', () => {
-      expect(aesthetic.generateClassName(['d'], ['size_df'], classes)).toBe('d_size_df');
+      expect(aesthetic.generateClassName(['d'], ['size:df'], classes)).toBe('d_size_df');
     });
   });
 
@@ -465,10 +465,8 @@ describe('Aesthetic', () => {
           color: 'black',
 
           '@variants': {
-            type: {
-              red: {
-                color: 'red',
-              },
+            'type:red': {
+              color: 'red',
             },
           },
         },
@@ -503,7 +501,7 @@ describe('Aesthetic', () => {
 
       expect(aesthetic.renderComponentStyles(sheet)).toEqual({
         foo: { result: 'a' },
-        bar: { result: 'b', variants: { type_red: 'c' }, variantTypes: new Set(['type']) },
+        bar: { result: 'b', variants: { 'type:red': 'c' }, variantTypes: new Set(['type']) },
         baz: { result: 'd' },
       });
       expect(spy).toHaveBeenCalledWith(aesthetic.getEngine(), lightTheme, {

--- a/packages/core/tests/GlobalSheet.test.ts
+++ b/packages/core/tests/GlobalSheet.test.ts
@@ -155,26 +155,26 @@ describe('GlobalSheet', () => {
     expect(spy).toHaveBeenCalledWith({ '--standard-syntax': 'true', '--custom-syntax': 123 });
   });
 
-  describe('variants', () => {
-    it('errors when adding color scheme variants', () => {
+  describe('overrides', () => {
+    it('errors when adding color scheme overrides', () => {
       expect(() => {
         // @ts-expect-error
-        sheet.addColorSchemeVariant('unknown', () => ({}));
-      }).toThrow('Color scheme variants are only supported by local style sheets.');
+        sheet.addColorSchemeOverride('unknown', () => ({}));
+      }).toThrow('Color scheme overrides are only supported by local style sheets.');
     });
 
-    it('errors when adding contrast level variants', () => {
+    it('errors when adding contrast level overrides', () => {
       expect(() => {
         // @ts-expect-error
-        sheet.addContrastVariant('unknown', () => ({}));
-      }).toThrow('Contrast level variants are only supported by local style sheets.');
+        sheet.addContrastOverride('unknown', () => ({}));
+      }).toThrow('Contrast level overrides are only supported by local style sheets.');
     });
 
-    it('errors when adding theme variants', () => {
+    it('errors when adding theme overrides', () => {
       expect(() => {
         // @ts-expect-error
-        sheet.addThemeVariant('unknown', () => ({}));
-      }).toThrow('Theme variants are only supported by local style sheets.');
+        sheet.addThemeOverride('unknown', () => ({}));
+      }).toThrow('Theme overrides are only supported by local style sheets.');
     });
   });
 });

--- a/packages/core/tests/LocalSheet.test.ts
+++ b/packages/core/tests/LocalSheet.test.ts
@@ -61,11 +61,9 @@ describe('LocalSheet', () => {
       baz: 'class-baz',
       qux: {
         '@variants': {
-          size: {
-            sm: { fontSize: 14 },
-            md: { fontSize: 16 },
-            lg: { fontSize: 18 },
-          },
+          'size:sm': { fontSize: 14 },
+          'size:md': { fontSize: 16 },
+          'size:lg': { fontSize: 18 },
         },
       },
     }));
@@ -103,9 +101,9 @@ describe('LocalSheet', () => {
       qux: {
         result: undefined,
         variants: {
-          size_lg: 'p',
-          size_md: 'o',
-          size_sm: 'n',
+          'size:lg': 'p',
+          'size:md': 'o',
+          'size:sm': 'n',
         },
         variantTypes: new Set(['size']),
       },
@@ -145,9 +143,9 @@ describe('LocalSheet', () => {
       qux: {
         result: undefined,
         variants: {
-          size_lg: 'p',
-          size_md: 'o',
-          size_sm: 'n',
+          'size:lg': 'p',
+          'size:md': 'o',
+          'size:sm': 'n',
         },
         variantTypes: new Set(['size']),
       },

--- a/packages/core/tests/LocalSheet.test.ts
+++ b/packages/core/tests/LocalSheet.test.ts
@@ -66,6 +66,19 @@ describe('LocalSheet', () => {
           'size:lg': { fontSize: 18 },
         },
       },
+      quxCompound: {
+        '@variants': {
+          'size:sm': { fontSize: 14 },
+          'size:md': { fontSize: 16 },
+          'size:lg': { fontSize: 18 },
+
+          'color:red': { color: 'red' },
+          'color:green': { color: 'green' },
+          'color:blue': { color: 'blue' },
+
+          'size:sm + color:green': { color: 'forestgreen' },
+        },
+      },
     }));
   });
 
@@ -83,31 +96,6 @@ describe('LocalSheet', () => {
           123,
         ),
     ).toThrow('A style sheet factory function is required, found "number".');
-  });
-
-  it('sets metadata for each element', () => {
-    const result = sheet.render(engine, lightTheme, {});
-
-    expect(result).toEqual({
-      bar: {
-        result: 'k l m',
-      },
-      baz: {
-        result: 'class-baz',
-      },
-      foo: {
-        result: 'a b c d e f g h i j',
-      },
-      qux: {
-        result: undefined,
-        variants: [
-          { match: ['size:sm'], result: 'n' },
-          { match: ['size:md'], result: 'o' },
-          { match: ['size:lg'], result: 'p' },
-        ],
-        variantTypes: new Set(['size']),
-      },
-    });
   });
 
   it('only renders once when cached', () => {
@@ -133,7 +121,7 @@ describe('LocalSheet', () => {
     expect(getRenderedStyles('standard')).toMatchSnapshot();
   });
 
-  it('renders and returns an object of class names', () => {
+  it('renders and returns an object of class names and variants', () => {
     const classes = sheet.render(engine, lightTheme, {});
 
     expect(classes).toEqual({
@@ -148,6 +136,19 @@ describe('LocalSheet', () => {
           { match: ['size:lg'], result: 'p' },
         ],
         variantTypes: new Set(['size']),
+      },
+      quxCompound: {
+        result: undefined,
+        variants: [
+          { match: ['size:sm'], result: 'q' },
+          { match: ['size:md'], result: 'r' },
+          { match: ['size:lg'], result: 's' },
+          { match: ['color:red'], result: 't' },
+          { match: ['color:green'], result: 'u' },
+          { match: ['color:blue'], result: 'v' },
+          { match: ['size:sm', 'color:green'], result: 'w' },
+        ],
+        variantTypes: new Set(['size', 'color']),
       },
     });
     expect(getRenderedStyles('standard')).toMatchSnapshot();

--- a/packages/core/tests/LocalSheet.test.ts
+++ b/packages/core/tests/LocalSheet.test.ts
@@ -207,28 +207,28 @@ describe('LocalSheet', () => {
     expect(getRenderedStyles('global')).toMatchSnapshot();
   });
 
-  describe('variants', () => {
+  describe('overrides', () => {
     beforeEach(() => {
-      sheet.addColorSchemeVariant('dark', () => ({
+      sheet.addColorSchemeOverride('dark', () => ({
         foo: {
           background: 'black',
           color: 'white',
         },
       }));
 
-      sheet.addContrastVariant('high', () => ({
+      sheet.addContrastOverride('high', () => ({
         foo: {
           background: 'pink',
         },
       }));
 
-      sheet.addContrastVariant('low', () => ({
+      sheet.addContrastOverride('low', () => ({
         foo: {
           background: 'yellow',
         },
       }));
 
-      sheet.addThemeVariant('danger', () => ({
+      sheet.addThemeOverride('danger', () => ({
         foo: {
           background: 'red',
           color: 'yellow',
@@ -238,22 +238,22 @@ describe('LocalSheet', () => {
 
     it('errors for invalid color scheme name', () => {
       expect(() => {
-        sheet.addColorSchemeVariant(
+        sheet.addColorSchemeOverride(
           // @ts-expect-error
           'unknown',
           () => ({}),
         );
-      }).toThrow('Color scheme variant must be one of "light" or "dark".');
+      }).toThrow('Color scheme override must be one of "light" or "dark".');
     });
 
     it('errors for invalid contrast name', () => {
       expect(() => {
-        sheet.addContrastVariant(
+        sheet.addContrastOverride(
           // @ts-expect-error
           'unknown',
           () => ({}),
         );
-      }).toThrow('Contrast level variant must be one of "high", "low", or "normal".');
+      }).toThrow('Contrast level override must be one of "high", "low", or "normal".');
     });
 
     it('inherits color scheme', () => {

--- a/packages/core/tests/LocalSheet.test.ts
+++ b/packages/core/tests/LocalSheet.test.ts
@@ -100,11 +100,11 @@ describe('LocalSheet', () => {
       },
       qux: {
         result: undefined,
-        variants: {
-          'size:lg': 'p',
-          'size:md': 'o',
-          'size:sm': 'n',
-        },
+        variants: [
+          { match: ['size:sm'], result: 'n' },
+          { match: ['size:md'], result: 'o' },
+          { match: ['size:lg'], result: 'p' },
+        ],
         variantTypes: new Set(['size']),
       },
     });
@@ -142,11 +142,11 @@ describe('LocalSheet', () => {
       baz: { result: 'class-baz' },
       qux: {
         result: undefined,
-        variants: {
-          'size:lg': 'p',
-          'size:md': 'o',
-          'size:sm': 'n',
-        },
+        variants: [
+          { match: ['size:sm'], result: 'n' },
+          { match: ['size:md'], result: 'o' },
+          { match: ['size:lg'], result: 'p' },
+        ],
         variantTypes: new Set(['size']),
       },
     });

--- a/packages/core/tests/__snapshots__/LocalSheet.test.ts.snap
+++ b/packages/core/tests/__snapshots__/LocalSheet.test.ts.snap
@@ -1,8 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`LocalSheet only renders once when cached 1`] = `".a {display: block;}.b {background: white;}.c {color: black;}.d {text-align: left;}.e {font-size: 12px;}.f {font-family: \\"Open Sans\\", Roboto;}.g:hover {color: red;}.j:focus {outline: red;}.k {transition: 200ms all;}.l {animation-name: kf1plt5bd;}.m {--primary-color: red;}.n {font-size: 14px;}.o {font-size: 16px;}.p {font-size: 18px;}"`;
+exports[`LocalSheet only renders once when cached 1`] = `".a {display: block;}.b {background: white;}.c {color: black;}.d {text-align: left;}.e {font-size: 12px;}.f {font-family: \\"Open Sans\\", Roboto;}.g:hover {color: red;}.j:focus {outline: red;}.k {transition: 200ms all;}.l {animation-name: kf1plt5bd;}.m {--primary-color: red;}.n {font-size: 14px;}.o {font-size: 16px;}.p {font-size: 18px;}.q {font-size: 14px;}.r {font-size: 16px;}.s {font-size: 18px;}.t {color: red;}.u {color: green;}.v {color: blue;}.w {color: forestgreen;}"`;
 
-exports[`LocalSheet re-renders when params change 1`] = `".a {display: block;}.b {background: white;}.c {color: black;}.d {text-align: left;}.e {font-size: 12px;}.f {font-family: \\"Open Sans\\", Roboto;}.g:hover {color: red;}.j:focus {outline: red;}.k {transition: 200ms all;}.l {animation-name: kf1plt5bd;}.m {--primary-color: red;}.n {font-size: 14px;}.o {font-size: 16px;}.p {font-size: 18px;}"`;
+exports[`LocalSheet re-renders when params change 1`] = `".a {display: block;}.b {background: white;}.c {color: black;}.d {text-align: left;}.e {font-size: 12px;}.f {font-family: \\"Open Sans\\", Roboto;}.g:hover {color: red;}.j:focus {outline: red;}.k {transition: 200ms all;}.l {animation-name: kf1plt5bd;}.m {--primary-color: red;}.n {font-size: 14px;}.o {font-size: 16px;}.p {font-size: 18px;}.q {font-size: 14px;}.r {font-size: 16px;}.s {font-size: 18px;}.t {color: red;}.u {color: green;}.v {color: blue;}.w {color: forestgreen;}"`;
 
 exports[`LocalSheet renders @font-face 1`] = `
 "@font-face {font-family: Roboto; font-style: normal; font-weight: normal; src: url('fonts/Roboto.woff2') format('woff2'), url('fonts/Roboto.ttf') format('truetype');}@keyframes kf1plt5bd { 
@@ -18,4 +18,4 @@ exports[`LocalSheet renders @keyframes 1`] = `
 }"
 `;
 
-exports[`LocalSheet renders and returns an object of class names 1`] = `".a {display: block;}.b {background: white;}.c {color: black;}.d {text-align: left;}.e {font-size: 12px;}.f {font-family: \\"Open Sans\\", Roboto;}.g:hover {color: red;}.j:focus {outline: red;}.k {transition: 200ms all;}.l {animation-name: kf1plt5bd;}.m {--primary-color: red;}.n {font-size: 14px;}.o {font-size: 16px;}.p {font-size: 18px;}"`;
+exports[`LocalSheet renders and returns an object of class names and variants 1`] = `".a {display: block;}.b {background: white;}.c {color: black;}.d {text-align: left;}.e {font-size: 12px;}.f {font-family: \\"Open Sans\\", Roboto;}.g:hover {color: red;}.j:focus {outline: red;}.k {transition: 200ms all;}.l {animation-name: kf1plt5bd;}.m {--primary-color: red;}.n {font-size: 14px;}.o {font-size: 16px;}.p {font-size: 18px;}.q {font-size: 14px;}.r {font-size: 16px;}.s {font-size: 18px;}.t {color: red;}.u {color: green;}.v {color: blue;}.w {color: forestgreen;}"`;

--- a/packages/sss/src/parsers/parseVariants.ts
+++ b/packages/sss/src/parsers/parseVariants.ts
@@ -1,28 +1,24 @@
 import { objectLoop } from '@aesthetic/utils';
 import Block from '../Block';
 import validateDeclarations from '../helpers/validateDeclarations';
-import { LocalBlockVariants, ParserOptions } from '../types';
+import { LocalBlockMap, ParserOptions } from '../types';
 import parseLocalBlock from './parseLocalBlock';
 
 export default function parseVariants<T extends object>(
   parent: Block<T>,
-  variants: LocalBlockVariants,
+  variants: LocalBlockMap,
   options: ParserOptions<T>,
 ) {
   if (__DEV__) {
     validateDeclarations(variants, '@variants');
   }
 
-  objectLoop(variants, (variant, parentType) => {
-    objectLoop(variant, (object, childType) => {
-      const type = `${parentType}_${childType}`;
+  objectLoop(variants, (object, variant) => {
+    const variantBlock = new Block();
+    parent.variants[variant] = variantBlock;
 
-      const variantBlock = new Block();
-      parent.variants[type] = variantBlock;
+    const block = parseLocalBlock(variantBlock, object, options);
 
-      const block = parseLocalBlock(variantBlock, object, options);
-
-      options.onVariant?.(parent, type, block, { specificity: 0 });
-    });
+    options.onVariant?.(parent, variant, block, { specificity: 0 });
   });
 }

--- a/packages/sss/src/parsers/parseVariants.ts
+++ b/packages/sss/src/parsers/parseVariants.ts
@@ -4,6 +4,12 @@ import validateDeclarations from '../helpers/validateDeclarations';
 import { LocalBlockMap, ParserOptions } from '../types';
 import parseLocalBlock from './parseLocalBlock';
 
+const VARIANT_PATTERN = /([a-z][a-z0-9]*:[a-z0-9_-]+)/iu;
+const COMBO_PATTERN = new RegExp(
+  `^${VARIANT_PATTERN.source}( \\+ ${VARIANT_PATTERN.source})*$`,
+  'iu',
+);
+
 export default function parseVariants<T extends object>(
   parent: Block<T>,
   variants: LocalBlockMap,
@@ -14,11 +20,20 @@ export default function parseVariants<T extends object>(
   }
 
   objectLoop(variants, (object, variant) => {
+    if (__DEV__) {
+      if (!COMBO_PATTERN.test(variant)) {
+        throw new Error(
+          `Invalid variant "${variant}". Type and enumeration must be separated with a ":", and each part may only contain a-z, 0-9, -, _.`,
+        );
+      }
+    }
+
     const variantBlock = new Block();
     parent.variants[variant] = variantBlock;
 
     const block = parseLocalBlock(variantBlock, object, options);
+    const list = variant.includes('+') ? variant.split('+').map((v) => v.trim()) : variant;
 
-    options.onVariant?.(parent, variant, block, { specificity: 0 });
+    options.onVariant?.(parent, list, block, { specificity: 0 });
   });
 }

--- a/packages/sss/src/types.ts
+++ b/packages/sss/src/types.ts
@@ -165,6 +165,13 @@ export type VariableListener<T extends object> = (
 
 export type VariablesListener = (variables: VariablesMap) => void;
 
+export type VariantListener<T extends object> = (
+  parent: Block<T>,
+  variant: string[] | string,
+  value: Block<T>,
+  params: NestedBlockParams,
+) => void;
+
 export interface ParserOptions<T extends object> {
   customProperties: PropertyHandlerMap;
   onAttribute?: NestedListener<T>;
@@ -178,7 +185,7 @@ export interface ParserOptions<T extends object> {
   onSelector?: NestedListener<T>;
   onSupports?: ConditionListener<T>;
   onVariable?: VariableListener<T>;
-  onVariant?: NestedListener<T>;
+  onVariant?: VariantListener<T>;
   // Local
   onClass?: ClassNameListener;
   onRule?: RuleListener<T>;

--- a/packages/sss/src/types.ts
+++ b/packages/sss/src/types.ts
@@ -68,12 +68,10 @@ export type LocalBlock = Rule & {
   '@selectors'?: LocalBlockMap;
   '@supports'?: LocalBlockMap;
   '@variables'?: VariablesMap;
-  '@variants'?: LocalBlockVariants;
+  '@variants'?: LocalBlockMap;
 };
 
 export type LocalBlockMap = Record<string, LocalBlock>;
-
-export type LocalBlockVariants = Record<string, LocalBlockMap>;
 
 export type LocalStyleSheet<B = LocalBlock> = RuleMap<B | string>;
 

--- a/packages/sss/tests/LocalParser.test.ts
+++ b/packages/sss/tests/LocalParser.test.ts
@@ -749,14 +749,14 @@ describe('LocalParser', () => {
 
       expect(spy).toHaveBeenCalledWith(
         expect.any(Block),
-        'size_small',
+        'size:small',
         createBlock('', { fontSize: 14 }),
         { specificity: 0 },
       );
 
       expect(spy).toHaveBeenCalledWith(
         expect.any(Block),
-        'size_large',
+        'size:large',
         createBlock('', { fontSize: 18 }),
         { specificity: 0 },
       );

--- a/packages/sss/tests/__mocks__/local.ts
+++ b/packages/sss/tests/__mocks__/local.ts
@@ -168,16 +168,14 @@ export const SYNTAX_VARIABLES: LocalBlock = {
 
 export const SYNTAX_VARIANTS: LocalBlock = {
   '@variants': {
-    size: {
-      small: {
-        fontSize: 14,
-      },
-      default: {
-        fontSize: 16,
-      },
-      large: {
-        fontSize: 18,
-      },
+    'size:small': {
+      fontSize: 14,
+    },
+    'size:default': {
+      fontSize: 16,
+    },
+    'size:large': {
+      fontSize: 18,
     },
   },
 };

--- a/packages/sss/tests/__mocks__/local.ts
+++ b/packages/sss/tests/__mocks__/local.ts
@@ -179,3 +179,11 @@ export const SYNTAX_VARIANTS: LocalBlock = {
     },
   },
 };
+
+export const SYNTAX_COMPOUND_VARIANTS: LocalBlock = {
+  '@variants': {
+    'size:large + palette:negative': {
+      fontWeight: 'bold',
+    },
+  },
+};

--- a/packages/sss/tests/__snapshots__/LocalParser.test.ts.snap
+++ b/packages/sss/tests/__snapshots__/LocalParser.test.ts.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`LocalParser @variants errors for invalid compound name 1`] = `"Invalid variant \\"type:value + broken\\". Type and enumeration must be separated with a \\":\\", and each part may only contain a-z, 0-9, -, _."`;
+
+exports[`LocalParser @variants errors if contains a space 1`] = `"Invalid variant \\"type:va lue\\". Type and enumeration must be separated with a \\":\\", and each part may only contain a-z, 0-9, -, _."`;
+
+exports[`LocalParser @variants errors if enum is empty 1`] = `"Invalid variant \\"type:\\". Type and enumeration must be separated with a \\":\\", and each part may only contain a-z, 0-9, -, _."`;
+
+exports[`LocalParser @variants errors if missing a colon 1`] = `"Invalid variant \\"foo\\". Type and enumeration must be separated with a \\":\\", and each part may only contain a-z, 0-9, -, _."`;
+
+exports[`LocalParser @variants errors if starts with a number 1`] = `"Invalid variant \\"9a:value\\". Type and enumeration must be separated with a \\":\\", and each part may only contain a-z, 0-9, -, _."`;


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/aesthetic-suite/framework/blob/main/CONTRIBUTING.md
-->

<!-- If fixing an issue, uncomment the following and include a link/issue number. -->

<!-- Fixes issue # -->

## Summary

Aesthetic has supported variants since basically the beginning with the `@variants` at-rule. While this has worked wonderfully, it _did not_ support compound variants (activate based on a combination of variants). Compound variants are very important as it allows for complex component styles to be built. For example, [Braid buttons](https://seek-oss.github.io/braid-design-system/components/Button) use compound for the color + background/border treatment. This kind of styling is currently very difficult with Aesthetic (would require multiple style sheets).

However, supporting compound variants was non-trivial as the syntax required was either too verbose, or not desirable, or just not a good experience. Before this PR, variants were defined using doubly-nested objects, like so:

```ts
const styleSheet = createComponentStyles((css) => ({
  button: {
    '@variants': {
      size: {
        sm: { fontSize: 14 },
        df: { fontSize: 16 },
        lg: { fontSize: 18 },
      },
    },
  },
}));
```

Because of this nesting, there's not an easy way to insert syntax for compound variants... so I looked towards other projects. [Stitches](https://stitches.dev/docs/variants#compound-variants) supports compound through a secondary property called `compoundVariants`, but when applied to Aesthetic, it's just far too verbose. It's also hard to scan/read at a glance.

```ts
const styleSheet = createComponentStyles((css) => ({
  button: {
    '@variants': {
      size: {
        sm: { fontSize: 14 },
        df: { fontSize: 16 },
        lg: { fontSize: 18 },
      },
    },
    '@compoundVariants': [
      {
        size: 'df',
        color: 'red',
        css: {
          borderColor: 'red',
        },
      },
    ],
  },
}));
```

So instead I opted to break and collapse the syntax to support both normal _and_ compound variants within `@variants`. While this is a little more verbose for the name (duplicating `size` each time), it was far less verbose for the styles, and took up far less vertical space (which was hard to follow in complex style sheets). This new syntax looks like the following, where compounds use `+` for combinations.

```ts
const styleSheet = createComponentStyles((css) => ({
  button: {
    '@variants': {
      'size:sm': { fontSize: 14 },
      'size:df': { fontSize: 16 },
      'size:lg': { fontSize: 18 },

      'size:df + color:red': {
        borderColor: 'red',
      },
    },
  },
}));
```

This has the added benefit of looking _more_ like CSS and the `@selectors` at-rule, which is nice.

## Screenshots

<!-- If applicable, screenshots or videos of the change working correctly. -->

## Checklist

- [x] Build passes with `yarn test`.
- [x] Code is formatted with `yarn format`.
- [x] Tests have been added for my changes.
- [x] Code coverage for my change is 100%.
- [x] Documentation has been updated for my changes.
